### PR TITLE
fix(lending): block deposit and borrow until cap settings are initialized

### DIFF
--- a/stellar-lend/contracts/lending/src/borrow.rs
+++ b/stellar-lend/contracts/lending/src/borrow.rs
@@ -13,6 +13,7 @@
 pub use crate::events::{BorrowCollateralDepositEvent, BorrowEvent, RepayEvent};
 
 /// Backward-compatible name for collateral added to a borrow position (see [`BorrowCollateralDepositEvent`]).
+#[allow(dead_code)]
 pub type DepositEvent = BorrowCollateralDepositEvent;
 
 use crate::pause::{self, PauseType};
@@ -41,6 +42,8 @@ pub enum BorrowError {
     BelowMinimumBorrow = 8,
     /// Repay amount exceeds current debt
     RepayAmountTooHigh = 9,
+    /// Borrow settings must be initialized before borrowing
+    SettingsNotInitialized = 10,
 }
 
 /// Storage keys for protocol-wide data.
@@ -111,6 +114,10 @@ pub fn borrow(
 
     if pause::is_paused(env, PauseType::Borrow) {
         return Err(BorrowError::ProtocolPaused);
+    }
+
+    if !is_borrow_settings_initialized(env) {
+        return Err(BorrowError::SettingsNotInitialized);
     }
 
     if amount <= 0 || collateral_amount <= 0 {
@@ -359,7 +366,7 @@ fn get_debt_ceiling(env: &Env) -> i128 {
     env.storage()
         .persistent()
         .get(&BorrowDataKey::BorrowDebtCeiling)
-        .unwrap_or(i128::MAX)
+        .unwrap_or(0)
 }
 
 fn get_min_borrow_amount(env: &Env) -> i128 {
@@ -367,6 +374,12 @@ fn get_min_borrow_amount(env: &Env) -> i128 {
         .persistent()
         .get(&BorrowDataKey::BorrowMinAmount)
         .unwrap_or(1000)
+}
+
+fn is_borrow_settings_initialized(env: &Env) -> bool {
+    env.storage()
+        .persistent()
+        .has(&BorrowDataKey::BorrowDebtCeiling)
 }
 
 fn emit_borrow_event(env: &Env, user: Address, asset: Address, amount: i128, collateral: i128) {

--- a/stellar-lend/contracts/lending/src/borrow_test.rs
+++ b/stellar-lend/contracts/lending/src/borrow_test.rs
@@ -43,6 +43,22 @@ fn test_borrow_success() {
 }
 
 #[test]
+fn test_borrow_fails_when_settings_not_initialized() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(LendingContract, ());
+    let client = LendingContractClient::new(&env, &contract_id);
+
+    let user = Address::generate(&env);
+    let asset = Address::generate(&env);
+    let collateral_asset = Address::generate(&env);
+
+    let result = client.try_borrow(&user, &asset, &10_000, &collateral_asset, &20_000);
+    assert_eq!(result, Err(Ok(BorrowError::SettingsNotInitialized)));
+}
+
+#[test]
 fn test_borrow_insufficient_collateral() {
     let env = Env::default();
     env.mock_all_auths();

--- a/stellar-lend/contracts/lending/src/deposit.rs
+++ b/stellar-lend/contracts/lending/src/deposit.rs
@@ -17,6 +17,7 @@ pub enum DepositError {
     Overflow = 3,
     AssetNotSupported = 4,
     ExceedsDepositCap = 5,
+    SettingsNotInitialized = 6,
 }
 
 /// Storage keys for deposit-related data
@@ -59,6 +60,10 @@ pub fn deposit(
 
     if pause::is_paused(env, PauseType::Deposit) {
         return Err(DepositError::DepositPaused);
+    }
+
+    if !is_deposit_settings_initialized(env) {
+        return Err(DepositError::SettingsNotInitialized);
     }
 
     if amount <= 0 {
@@ -148,7 +153,7 @@ fn get_deposit_cap(env: &Env) -> i128 {
     env.storage()
         .persistent()
         .get(&DepositDataKey::CapAmount)
-        .unwrap_or(i128::MAX)
+        .unwrap_or(0)
 }
 
 fn get_min_deposit_amount(env: &Env) -> i128 {
@@ -156,6 +161,10 @@ fn get_min_deposit_amount(env: &Env) -> i128 {
         .persistent()
         .get(&DepositDataKey::MinAmount)
         .unwrap_or(0)
+}
+
+fn is_deposit_settings_initialized(env: &Env) -> bool {
+    env.storage().persistent().has(&DepositDataKey::CapAmount)
 }
 
 fn emit_deposit_event(env: &Env, user: Address, asset: Address, amount: i128, new_balance: i128) {

--- a/stellar-lend/contracts/lending/src/deposit_test.rs
+++ b/stellar-lend/contracts/lending/src/deposit_test.rs
@@ -25,6 +25,21 @@ fn test_deposit_success() {
 }
 
 #[test]
+fn test_deposit_fails_when_settings_not_initialized() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(LendingContract, ());
+    let client = LendingContractClient::new(&env, &contract_id);
+
+    let user = Address::generate(&env);
+    let asset = Address::generate(&env);
+
+    let result = client.try_deposit(&user, &asset, &10_000);
+    assert_eq!(result, Err(Ok(DepositError::SettingsNotInitialized)));
+}
+
+#[test]
 fn test_deposit_invalid_amount_zero() {
     let env = Env::default();
     env.mock_all_auths();

--- a/stellar-lend/contracts/lending/src/pause_test.rs
+++ b/stellar-lend/contracts/lending/src/pause_test.rs
@@ -20,6 +20,7 @@ fn test_pause_borrow_granular() {
     let collateral_asset = Address::generate(&env);
 
     client.initialize(&admin, &1_000_000_000, &1000);
+    client.initialize_deposit_settings(&1_000_000_000, &100);
 
     // Initial state: not paused
     client.borrow(&user, &asset, &10_000, &collateral_asset, &20_000);
@@ -53,6 +54,7 @@ fn test_global_pause() {
     let collateral_asset = Address::generate(&env);
 
     client.initialize(&admin, &1_000_000_000, &1000);
+    client.initialize_deposit_settings(&1_000_000_000, &100);
 
     // Pause all
     client.set_pause(&admin, &PauseType::All, &true);
@@ -100,6 +102,7 @@ fn test_set_pause_unauthorized_address() {
     let user = Address::generate(&env);
 
     client.initialize(&admin, &1_000_000_000, &1000);
+    client.initialize_deposit_settings(&1_000_000_000, &100);
 
     // Try to set pause with non-admin address
     client.set_pause(&user, &PauseType::Borrow, &true);

--- a/stellar-lend/contracts/lending/test_snapshots/pause_test/test_global_pause.1.json
+++ b/stellar-lend/contracts/lending/test_snapshots/pause_test/test_global_pause.1.json
@@ -7,6 +7,7 @@
   "auth": [
     [],
     [],
+    [],
     [
       [
         "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
@@ -378,6 +379,84 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CapAmount"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CapAmount"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": "1000000000"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "MinAmount"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "MinAmount"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": "100"
                 }
               }
             },

--- a/stellar-lend/contracts/lending/test_snapshots/pause_test/test_pause_borrow_granular.1.json
+++ b/stellar-lend/contracts/lending/test_snapshots/pause_test/test_pause_borrow_granular.1.json
@@ -7,6 +7,7 @@
   "auth": [
     [],
     [],
+    [],
     [
       [
         "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
@@ -405,6 +406,84 @@
                       }
                     }
                   ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CapAmount"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CapAmount"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": "1000000000"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "MinAmount"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "MinAmount"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": "100"
                 }
               }
             },

--- a/stellar-lend/contracts/lending/test_snapshots/pause_test/test_set_pause_unauthorized_address.1.json
+++ b/stellar-lend/contracts/lending/test_snapshots/pause_test/test_set_pause_unauthorized_address.1.json
@@ -7,6 +7,7 @@
   "auth": [
     [],
     [],
+    [],
     []
   ],
   "ledger": {
@@ -89,6 +90,84 @@
                 "durability": "persistent",
                 "val": {
                   "i128": "1000"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CapAmount"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CapAmount"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": "1000000000"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "MinAmount"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "MinAmount"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": "100"
                 }
               }
             },


### PR DESCRIPTION

## Summary
This PR resolves issue #23 by removing unsafe unlimited defaults for deposit cap and debt ceiling.

Before this change:
- Deposit cap defaulted to max i128 when unset
- Debt ceiling defaulted to max i128 when unset

After this change:
- Deposit and borrow operations require explicit cap initialization
- Calls fail fast with clear not-initialized contract errors when settings are missing

## What Changed
- Added explicit initialization guard for deposit settings
- Added explicit initialization guard for borrow settings
- Added dedicated error variants for uninitialized settings in both modules
- Replaced unlimited fallback behavior for cap and ceiling with safe fallback behavior
- Added tests for pre-initialization failure cases
- Updated pause-related tests and snapshots to keep existing setup flows valid under the new guard

## Acceptance Criteria Mapping
- Protocol operations blocked until caps are explicitly configured:
  - Deposit now fails when deposit settings are not initialized
  - Borrow now fails when borrow settings are not initialized

- Clear error message when caps not initialized:
  - Deposit returns SettingsNotInitialized
  - Borrow returns SettingsNotInitialized

- Tests verify operations fail before initialization:
  - Added deposit test for missing initialization
  - Added borrow test for missing initialization

## Testing Evidence
Executed in lending contract crate:
- cargo fmt
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- cargo test

Result:
- All checks passed
- 161 tests passed, 0 failed

## Risks
- Integrations relying on implicit unlimited behavior will now fail until initialization is performed

## Rollback
- Revert the two commits introduced in this branch:
  - fix(lending): require cap and ceiling initialization
  - test(lending): cover uninitialized caps and update pause fixtures

## Linked Issue
Closes #23