### PR TITLE
feat(pagination): opaque cursor encoding, total count field, and comp…

### DIFF
--- a/api/src/__tests__/lending.controller.test.ts
+++ b/api/src/__tests__/lending.controller.test.ts
@@ -63,6 +63,7 @@ const mockStellarService: jest.Mocked<StellarService> = {
       cursor: null,
       hasMore: false,
       limit: 10,
+      total: null,
     },
   }),
 } as any;
@@ -278,7 +279,7 @@ describe('Lending Controller', () => {
       expect(response.body).toHaveProperty('data');
       expect(Array.isArray(response.body.data)).toBe(true);
       expect(response.body).toHaveProperty('pagination');
-      expect(response.body.pagination).toEqual({ cursor: null, hasMore: false, limit: 10 });
+      expect(response.body.pagination).toEqual({ cursor: null, hasMore: false, limit: 10, total: null });
       expect(response.body.data[0]).toMatchObject({ transactionHash: 'tx_hash_1' });
     });
 
@@ -298,6 +299,73 @@ describe('Lending Controller', () => {
 
       expect(response.status).toBe(400);
       expect(response.body.error).toMatch(/cursor/i);
+    });
+
+    it('should reject a cursor that is not valid base64url', async () => {
+      const response = await request(app)
+        .get(`/api/lending/transactions/${userAddress}`)
+        .query({ cursor: '!!!not-a-valid-cursor!!!' });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toMatch(/cursor/i);
+    });
+
+    it('should return an opaque base64url cursor when hasMore is true', async () => {
+      mockStellarService.getTransactionHistory.mockResolvedValueOnce({
+        data: [],
+        pagination: {
+          cursor: 'aGVsbG8',
+          hasMore: true,
+          limit: 10,
+          total: null,
+        },
+      });
+
+      const response = await request(app).get(`/api/lending/transactions/${userAddress}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.pagination.hasMore).toBe(true);
+      expect(response.body.pagination.cursor).not.toBeNull();
+      // Cursor must be a non-empty string opaque to the client
+      expect(typeof response.body.pagination.cursor).toBe('string');
+      expect(response.body.pagination.cursor.length).toBeGreaterThan(0);
+    });
+
+    it('should include total: null on the first page when total count is unavailable', async () => {
+      const response = await request(app).get(`/api/lending/transactions/${userAddress}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.pagination).toHaveProperty('total');
+      expect(response.body.pagination.total).toBeNull();
+    });
+
+    it('should respect a custom limit parameter', async () => {
+      mockStellarService.getTransactionHistory.mockResolvedValueOnce({
+        data: [],
+        pagination: { cursor: null, hasMore: false, limit: 5, total: null },
+      });
+
+      const response = await request(app)
+        .get(`/api/lending/transactions/${userAddress}`)
+        .query({ limit: 5 });
+
+      expect(response.status).toBe(200);
+      expect(response.body.pagination.limit).toBe(5);
+    });
+
+    it('should accept a valid base64url cursor and forward it', async () => {
+      const rawCursor = 'some-horizon-cursor-token';
+      const encodedCursor = Buffer.from(rawCursor, 'utf8').toString('base64url');
+
+      const response = await request(app)
+        .get(`/api/lending/transactions/${userAddress}`)
+        .query({ cursor: encodedCursor });
+
+      expect(response.status).toBe(200);
+      // Service should have been called with the decoded raw cursor
+      expect(mockStellarService.getTransactionHistory).toHaveBeenCalledWith(
+        expect.objectContaining({ cursor: rawCursor })
+      );
     });
   });
 

--- a/api/src/__tests__/pagination.test.ts
+++ b/api/src/__tests__/pagination.test.ts
@@ -1,0 +1,105 @@
+import { encodeCursor, decodeCursor, parsePaginationParams, buildPaginationMeta } from '../utils/pagination';
+import { ValidationError } from '../utils/errors';
+
+describe('encodeCursor / decodeCursor', () => {
+  it('round-trips arbitrary cursor strings', () => {
+    const raw = 'horizon-cursor-12345';
+    expect(decodeCursor(encodeCursor(raw))).toBe(raw);
+  });
+
+  it('produces a base64url string without padding characters', () => {
+    const encoded = encodeCursor('abc');
+    expect(encoded).not.toMatch(/[+/=]/);
+  });
+
+  it('returns null for an empty base64url decoded value', () => {
+    expect(decodeCursor('')).toBeNull();
+  });
+
+  it('returns null for a non-base64url input', () => {
+    expect(decodeCursor('!!! invalid !!!')).toBeNull();
+    expect(decodeCursor('has spaces')).toBeNull();
+    expect(decodeCursor('has+plus/slash=')).toBeNull();
+  });
+
+  it('handles cursors with special characters', () => {
+    const raw = 'cursor with spaces & special=chars?foo=bar';
+    expect(decodeCursor(encodeCursor(raw))).toBe(raw);
+  });
+});
+
+describe('parsePaginationParams', () => {
+  it('returns default limit when none provided', () => {
+    const result = parsePaginationParams({});
+    expect(typeof result.limit).toBe('number');
+    expect(result.limit).toBeGreaterThan(0);
+  });
+
+  it('parses a valid limit', () => {
+    const result = parsePaginationParams({ limit: '25' });
+    expect(result.limit).toBe(25);
+  });
+
+  it('throws ValidationError for a non-integer limit', () => {
+    expect(() => parsePaginationParams({ limit: 'abc' })).toThrow(ValidationError);
+  });
+
+  it('throws ValidationError for a zero limit', () => {
+    expect(() => parsePaginationParams({ limit: '0' })).toThrow(ValidationError);
+  });
+
+  it('throws ValidationError for a negative limit', () => {
+    expect(() => parsePaginationParams({ limit: '-5' })).toThrow(ValidationError);
+  });
+
+  it('returns cursor: null when no cursor provided', () => {
+    const result = parsePaginationParams({});
+    expect(result.cursor).toBeNull();
+  });
+
+  it('decodes a valid opaque cursor', () => {
+    const raw = 'horizon-paging-token-99';
+    const encoded = encodeCursor(raw);
+    const result = parsePaginationParams({ cursor: encoded });
+    expect(result.cursor).toBe(raw);
+  });
+
+  it('throws ValidationError for an empty cursor', () => {
+    expect(() => parsePaginationParams({ cursor: '' })).toThrow(ValidationError);
+    expect(() => parsePaginationParams({ cursor: '   ' })).toThrow(ValidationError);
+  });
+
+  it('throws ValidationError for a malformed cursor', () => {
+    expect(() => parsePaginationParams({ cursor: 'this-is-not-base64url!!!' })).toThrow(ValidationError);
+  });
+});
+
+describe('buildPaginationMeta', () => {
+  it('encodes the raw next cursor as an opaque string', () => {
+    const raw = 'next-paging-token';
+    const meta = buildPaginationMeta(raw, true, 10);
+    expect(meta.cursor).toBe(encodeCursor(raw));
+    expect(meta.cursor).not.toBe(raw);
+  });
+
+  it('sets cursor to null when there is no next page', () => {
+    const meta = buildPaginationMeta(null, false, 10);
+    expect(meta.cursor).toBeNull();
+    expect(meta.hasMore).toBe(false);
+  });
+
+  it('includes total when provided', () => {
+    const meta = buildPaginationMeta(null, false, 10, 42);
+    expect(meta.total).toBe(42);
+  });
+
+  it('defaults total to null when not provided', () => {
+    const meta = buildPaginationMeta(null, false, 10);
+    expect(meta.total).toBeNull();
+  });
+
+  it('preserves the limit in the response', () => {
+    const meta = buildPaginationMeta(null, false, 25);
+    expect(meta.limit).toBe(25);
+  });
+});

--- a/api/src/types/pagination.ts
+++ b/api/src/types/pagination.ts
@@ -4,9 +4,12 @@ export interface PaginationParams {
 }
 
 export interface PaginationMeta {
+  /** Opaque cursor for the next page. Null if no further pages exist. */
   cursor: string | null;
   hasMore: boolean;
   limit: number;
+  /** Total item count, included only on the first page (no cursor). Null when unavailable from upstream. */
+  total: number | null;
 }
 
 export interface PaginatedResponse<T> {

--- a/api/src/utils/pagination.ts
+++ b/api/src/utils/pagination.ts
@@ -6,6 +6,30 @@ function isPositiveInteger(value: number): boolean {
   return Number.isInteger(value) && value > 0;
 }
 
+/**
+ * Encode a raw upstream cursor as an opaque base64url string so callers
+ * cannot depend on its internal format.
+ */
+export function encodeCursor(raw: string): string {
+  return Buffer.from(raw, 'utf8').toString('base64url');
+}
+
+const BASE64URL_RE = /^[A-Za-z0-9_-]+$/;
+
+/**
+ * Decode a client-supplied opaque cursor back to the raw upstream value.
+ * Returns null when the input is not valid base64url or decoding is empty.
+ */
+export function decodeCursor(opaque: string): string | null {
+  if (!opaque || !BASE64URL_RE.test(opaque)) return null;
+  try {
+    const decoded = Buffer.from(opaque, 'base64url').toString('utf8');
+    return decoded.length > 0 ? decoded : null;
+  } catch {
+    return null;
+  }
+}
+
 export function parsePaginationParams(rawQuery: Record<string, any> = {}): PaginationParams {
   const limitFromQuery = rawQuery.limit;
   const cursorFromQuery = rawQuery.cursor;
@@ -35,7 +59,11 @@ export function parsePaginationParams(rawQuery: Record<string, any> = {}): Pagin
     if (normalizedCursor.length === 0) {
       throw new ValidationError('cursor cannot be empty');
     }
-    cursor = normalizedCursor;
+    const decoded = decodeCursor(normalizedCursor);
+    if (decoded === null) {
+      throw new ValidationError('cursor is invalid or expired');
+    }
+    cursor = decoded;
   }
 
   return {
@@ -45,13 +73,15 @@ export function parsePaginationParams(rawQuery: Record<string, any> = {}): Pagin
 }
 
 export function buildPaginationMeta(
-  cursor: string | null,
+  rawNextCursor: string | null,
   hasMore: boolean,
-  limit: number
+  limit: number,
+  total: number | null = null
 ): PaginationMeta {
   return {
-    cursor,
+    cursor: rawNextCursor !== null ? encodeCursor(rawNextCursor) : null,
     hasMore,
     limit,
+    total,
   };
 }


### PR DESCRIPTION
<h2 style="color: rgb(154, 162, 203); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 16, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">PR 1 —<span> </span><code style="font-family: monospace; color: rgb(234, 205, 97); background-color: rgb(56, 51, 48); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">feat/cursor-pagination-improvements</code><span> </span>→ Closes #205</h2><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(154, 162, 203); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(13, 16, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>Title:</strong> <code style="font-family: monospace; color: rgb(234, 205, 97); background-color: rgb(56, 51, 48); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">perf(pagination): opaque cursor encoding, total count field, and comprehensive tests</code></p><hr style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 16, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><h3 style="color: rgb(154, 162, 203); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 16, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Summary</h3><ul style="padding-inline-start: 2em; color: rgb(154, 162, 203); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 16, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li>Cursors are now encoded as opaque<span> </span><strong>base64url</strong><span> </span>strings — clients can no longer depend on the raw Horizon paging token format, making the contract stable across upstream changes</li><li>Added<span> </span><code style="font-family: monospace; color: rgb(234, 205, 97); background-color: rgb(56, 51, 48); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">total: number | null</code><span> </span>to<span> </span><code style="font-family: monospace; color: rgb(234, 205, 97); background-color: rgb(56, 51, 48); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">PaginationMeta</code>; returned as<span> </span><code style="font-family: monospace; color: rgb(234, 205, 97); background-color: rgb(56, 51, 48); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">null</code><span> </span>when the upstream (Horizon) cannot cheaply provide a count,<span> </span><code style="font-family: monospace; color: rgb(234, 205, 97); background-color: rgb(56, 51, 48); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">null</code><span> </span>on subsequent pages to avoid stale data</li><li><code style="font-family: monospace; color: rgb(234, 205, 97); background-color: rgb(56, 51, 48); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">parsePaginationParams</code><span> </span>now<span> </span><strong>validates and decodes</strong><span> </span>the opaque cursor, returning a clear<span> </span><code style="font-family: monospace; color: rgb(234, 205, 97); background-color: rgb(56, 51, 48); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">400 cursor is invalid or expired</code><span> </span>error for malformed input rather than silently passing garbage to Horizon</li><li>Added a dedicated<span> </span><code style="font-family: monospace; color: rgb(234, 205, 97); background-color: rgb(56, 51, 48); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">pagination.test.ts</code><span> </span>unit suite (19 tests) covering round-trips, edge cases, invalid inputs, and<span> </span><code style="font-family: monospace; color: rgb(234, 205, 97); background-color: rgb(56, 51, 48); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">buildPaginationMeta</code><span> </span>behaviour</li></ul><h3 style="color: rgb(154, 162, 203); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 16, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Files changed</h3>
File | Change
-- | --
api/src/types/pagination.ts | Added total: number \| null to PaginationMeta
api/src/utils/pagination.ts | Added encodeCursor, decodeCursor (base64url + regex guard); updated buildPaginationMeta signature
api/src/__tests__/pagination.test.ts | New — 19 unit tests
api/src/__tests__/lending.controller.test.ts | Updated mock shape; added 5 integration tests for cursor round-trip, invalid cursor rejection, total field, custom limit

<h3 style="color: rgb(154, 162, 203); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 16, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Test plan</h3><ul class="contains-task-list" style="padding-inline-start: 2em; color: rgb(154, 162, 203); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 16, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li class="task-list-item"><input type="checkbox" disabled="" style="appearance: none; border-color: rgb(34, 40, 68); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; position: relative; pointer-events: none; vertical-align: middle; border-radius: 2px; width: 1em; height: 1em; margin: 2px 4px 2px 2px;"><span> </span><code style="font-family: monospace; color: rgb(234, 205, 97); background-color: rgb(56, 51, 48); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">npm test --testPathPattern=auditLog</code><span> </span>— all 15 tests green</li><li class="task-list-item"><input type="checkbox" disabled="" style="appearance: none; border-color: rgb(34, 40, 68); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; position: relative; pointer-events: none; vertical-align: middle; border-radius: 2px; width: 1em; height: 1em; margin: 2px 4px 2px 2px;"><span> </span>Submit a transaction →<span> </span><code style="font-family: monospace; color: rgb(234, 205, 97); background-color: rgb(56, 51, 48); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">GET /protocol/audit-logs?action=DEPOSIT</code><span> </span>returns the entry with correct actor/txHash/ledger</li><li class="task-list-item"><input type="checkbox" disabled="" style="appearance: none; border-color: rgb(34, 40, 68); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; position: relative; pointer-events: none; vertical-align: middle; border-radius: 2px; width: 1em; height: 1em; margin: 2px 4px 2px 2px;"><span> </span><code style="font-family: monospace; color: rgb(234, 205, 97); background-color: rgb(56, 51, 48); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">GET /protocol/audit-logs/verify</code><span> </span>→<span> </span><code style="font-family: monospace; color: rgb(234, 205, 97); background-color: rgb(56, 51, 48); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">{ valid: true }</code></li><li class="task-list-item"><input type="checkbox" disabled="" style="appearance: none; border-color: rgb(34, 40, 68); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; position: relative; pointer-events: none; vertical-align: middle; border-radius: 2px; width: 1em; height: 1em; margin: 2px 4px 2px 2px;"><span> </span>Manually mutate an entry field →<span> </span><code style="font-family: monospace; color: rgb(234, 205, 97); background-color: rgb(56, 51, 48); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">GET /protocol/audit-logs/verify</code><span> </span>→<span> </span><code style="font-family: monospace; color: rgb(234, 205, 97); background-color: rgb(56, 51, 48); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">409</code><span> </span>with<span> </span><code style="font-family: monospace; color: rgb(234, 205, 97); background-color: rgb(56, 51, 48); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">firstBadSequence</code></li><li class="task-list-item"><input type="checkbox" disabled="" style="appearance: none; border-color: rgb(34, 40, 68); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; position: relative; pointer-events: none; vertical-align: middle; border-radius: 2px; width: 1em; height: 1em; margin: 2px 4px 2px 2px;"><span> </span><code style="font-family: monospace; color: rgb(234, 205, 97); background-color: rgb(56, 51, 48); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">GET /protocol/audit-logs/export</code><span> </span>→ downloads<span> </span><code style="font-family: monospace; color: rgb(234, 205, 97); background-color: rgb(56, 51, 48); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">audit-logs.json</code><span> </span>with valid JSON array</li><li class="task-list-item"><input type="checkbox" disabled="" style="appearance: none; border-color: rgb(34, 40, 68); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; position: relative; pointer-events: none; vertical-align: middle; border-radius: 2px; width: 1em; height: 1em; margin: 2px 4px 2px 2px;"><span> </span>Pause then resume protocol → both appear in audit log with<span> </span><code style="font-family: monospace; color: rgb(234, 205, 97); background-color: rgb(56, 51, 48); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">beforeState</code>/<code style="font-family: monospace; color: rgb(234, 205, 97); background-color: rgb(56, 51, 48); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">afterState</code></li><li class="task-list-item"><input type="checkbox" disabled="" style="appearance: none; border-color: rgb(34, 40, 68); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; position: relative; pointer-events: none; vertical-align: middle; border-radius: 2px; width: 1em; height: 1em; margin: 2px 4px 2px 2px;"><span> </span>Assign a role →<span> </span><code style="font-family: monospace; color: rgb(234, 205, 97); background-color: rgb(56, 51, 48); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">ROLE_ASSIGNED</code><span> </span>entry appears with<span> </span><code style="font-family: monospace; color: rgb(234, 205, 97); background-color: rgb(56, 51, 48); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">targetAddress</code>,<span> </span><code style="font-family: monospace; color: rgb(234, 205, 97); background-color: rgb(56, 51, 48); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">targetRole</code>,<span> </span><code style="font-family: monospace; color: rgb(234, 205, 97); background-color: rgb(56, 51, 48); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">assignedBy</code></li></ul>

closes #205  