### PR TITLE
Split API routes by domain with versioned namespacing

### DIFF
--- a/health.routes.ts
+++ b/health.routes.ts
@@ -1,0 +1,15 @@
+import { Router } from 'express';
+import {
+  getHealthStatus,
+  getLivenessStatus,
+  getReadinessStatus,
+} from '../../controllers/lending.controller';
+
+const router = Router();
+
+// Health checks
+router.get('/', getHealthStatus);
+router.get('/live', getLivenessStatus);
+router.get('/ready', getReadinessStatus);
+
+export default router;

--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,13 @@
+import { Router } from 'express';
+import lendingV1Routes from './v1/lending.routes';
+import healthV1Routes from './v1/health.routes';
+import protocolV1Routes from './v1/protocol.routes';
+
+const router = Router();
+
+// Version 1 API routes
+router.use('/v1/lending', lendingV1Routes);
+router.use('/v1/health', healthV1Routes);
+router.use('/v1/protocol', protocolV1Routes);
+
+export default router;

--- a/lending.routes.ts
+++ b/lending.routes.ts
@@ -1,0 +1,35 @@
+import { Router } from 'express';
+import {
+  prepareLendingOperation,
+  submitSignedXdr,
+} from '../../controllers/lending.controller';
+import {
+  prepareValidation,
+  submitValidation,
+} from '../../middleware/validation';
+import { authenticateToken } from '../../middleware/auth';
+import { bodySizeLimitMiddleware } from '../../middleware/bodySizeLimit';
+import { perUserRateLimit } from '../../middleware/rateLimit';
+import { idempotencyMiddleware } from '../../middleware/idempotency';
+
+const router = Router();
+
+// Lending operations
+router.get(
+  '/prepare/:operation',
+  authenticateToken,
+  perUserRateLimit,
+  prepareValidation,
+  prepareLendingOperation
+);
+router.post(
+  '/submit',
+  authenticateToken,
+  perUserRateLimit,
+  bodySizeLimitMiddleware,
+  idempotencyMiddleware,
+  submitValidation,
+  submitSignedXdr
+);
+
+export default router;

--- a/protocol.routes.ts
+++ b/protocol.routes.ts
@@ -1,0 +1,11 @@
+import { Router } from 'express';
+import {
+  getProtocolStats,
+} from '../../controllers/lending.controller';
+
+const router = Router();
+
+// Protocol stats
+router.get('/stats', getProtocolStats);
+
+export default router;


### PR DESCRIPTION
Closes #123

# Refactor API routing into a versioned, domain-based structure to improve organization, scalability, and maintainability.

### What Changed

* Added `api/src/routes/v1/` for versioned API routes
* Split routes into domain-specific files:

  * `lending.routes.ts`
  * `health.routes.ts`
  * `protocol.routes.ts`
* Introduced centralized API router in `api/src/routes/index.ts`
* Updated `api/src/app.ts` to mount routes under `/api/v1/*`
* Removed legacy flat `lending.routes.ts`

### Benefits

* Clear API versioning strategy
* Better route organization by domain
* Easier future expansion (`v2`, new domains, etc.)
* Improved maintainability and reduced routing complexity
* No changes to controllers, middleware, or business logic

### Endpoint Structure

All routes now follow:

```txt
/api/v1/<domain>/<endpoint>
```

Examples:

* `/api/v1/lending/prepare`
* `/api/v1/health/live`
* `/api/v1/protocol/stats`
