### PR TITLE
feat: implement MEV protection mechanisms

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -17,6 +17,7 @@ import zkProofRoutes from './routes/zkProof.routes';
 import verificationRoutes from './routes/verification.routes';
 import configRoutes from './routes/config.routes';
 import analyticsRoutes from './routes/analytics.routes';
+import mevRoutes from './routes/mev.routes';
 import { errorHandler } from './middleware/errorHandler';
 import { idempotencyMiddleware } from './middleware/idempotency';
 import { swaggerSpec } from './config/swagger';
@@ -111,6 +112,7 @@ app.use('/api/zk', zkProofRoutes);
 app.use('/api/verification', verificationRoutes);
 app.use('/api/config', configRoutes);
 app.use('/api/analytics', analyticsRoutes);
+app.use('/api/mev', mevRoutes);
 
 app.use(errorHandler);
 

--- a/api/src/controllers/mev.controller.ts
+++ b/api/src/controllers/mev.controller.ts
@@ -1,0 +1,304 @@
+/**
+ * MEV Protection Controller
+ *
+ * Endpoints:
+ *  POST /mev/commit              — build unsigned commit transaction
+ *  POST /mev/reveal              — build unsigned reveal transaction
+ *  POST /mev/auction/bid         — build unsigned auction bid transaction
+ *  POST /mev/auction/settle      — build unsigned auction settle transaction
+ *  GET  /mev/auction/:slotId     — query settled auction result
+ *  GET  /mev/auction/current     — current open auction slot
+ *  GET  /mev/dashboard           — MEV extraction monitoring dashboard
+ *  GET  /mev/gas-analysis        — gas price bidding analysis
+ *  GET  /mev/route               — private mempool routing hint
+ *  GET  /mev/fee-preview         — preview effective MEV fee
+ */
+
+import { Request, Response, NextFunction } from 'express';
+import { mevService, SensitiveOperation, TxOrderingHint } from '../services/mev.service';
+import { ValidationError } from '../utils/errors';
+import logger from '../utils/logger';
+
+// ─── Commit ───────────────────────────────────────────────────────────────────
+
+export const buildCommit = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    const {
+      userAddress,
+      operation,
+      assetAddress,
+      secondaryAssetAddress,
+      borrowerAddress,
+      amount,
+      maxFeeBps,
+      hint,
+      maxSlippageBps,
+      deadline,
+    } = req.body as any;
+
+    if (!userAddress || !operation || !amount || maxFeeBps === undefined) {
+      throw new ValidationError('userAddress, operation, amount, and maxFeeBps are required');
+    }
+
+    const validOps: SensitiveOperation[] = ['Borrow', 'Withdraw', 'Liquidate'];
+    if (!validOps.includes(operation)) {
+      throw new ValidationError(`operation must be one of: ${validOps.join(', ')}`);
+    }
+
+    if (operation === 'Liquidate' && !borrowerAddress) {
+      throw new ValidationError('borrowerAddress is required for Liquidate operations');
+    }
+
+    logger.info('Building MEV commit transaction', { userAddress, operation, amount });
+
+    const result = await mevService.buildCommitTransaction({
+      userAddress,
+      operation,
+      assetAddress,
+      secondaryAssetAddress,
+      borrowerAddress,
+      amount: String(amount),
+      maxFeeBps: Number(maxFeeBps),
+      hint: (hint as TxOrderingHint) ?? 'Default',
+      maxSlippageBps: maxSlippageBps !== undefined ? Number(maxSlippageBps) : undefined,
+      deadline: deadline !== undefined ? Number(deadline) : undefined,
+    });
+
+    res.status(200).json({ success: true, data: result });
+  } catch (err) {
+    next(err);
+  }
+};
+
+// ─── Reveal ───────────────────────────────────────────────────────────────────
+
+export const buildReveal = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    const { userAddress, commitId, operation } = req.body as any;
+
+    if (!userAddress || !commitId || !operation) {
+      throw new ValidationError('userAddress, commitId, and operation are required');
+    }
+
+    logger.info('Building MEV reveal transaction', { userAddress, commitId, operation });
+
+    const unsignedXdr = await mevService.buildRevealTransaction({
+      userAddress,
+      commitId: String(commitId),
+      operation: operation as SensitiveOperation,
+    });
+
+    res.status(200).json({ success: true, data: { unsignedXdr, commitId, operation } });
+  } catch (err) {
+    next(err);
+  }
+};
+
+// ─── Batch Auction ────────────────────────────────────────────────────────────
+
+export const buildAuctionBid = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    const {
+      bidderAddress,
+      borrowerAddress,
+      debtAmount,
+      minCollateralOut,
+      maxFeeBps,
+      deadline,
+    } = req.body as any;
+
+    if (!bidderAddress || !borrowerAddress || !debtAmount || !minCollateralOut || maxFeeBps === undefined) {
+      throw new ValidationError(
+        'bidderAddress, borrowerAddress, debtAmount, minCollateralOut, and maxFeeBps are required',
+      );
+    }
+
+    logger.info('Building batch auction bid', { bidderAddress, borrowerAddress, debtAmount });
+
+    const result = await mevService.buildPlaceAuctionBidTransaction({
+      bidderAddress,
+      borrowerAddress,
+      debtAmount: String(debtAmount),
+      minCollateralOut: String(minCollateralOut),
+      maxFeeBps: Number(maxFeeBps),
+      deadline: deadline !== undefined ? Number(deadline) : undefined,
+    });
+
+    res.status(200).json({ success: true, data: result });
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const buildSettleAuction = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    const { callerAddress, slotId } = req.body as any;
+
+    if (!callerAddress || slotId === undefined) {
+      throw new ValidationError('callerAddress and slotId are required');
+    }
+
+    logger.info('Building settle auction transaction', { callerAddress, slotId });
+
+    const unsignedXdr = await mevService.buildSettleAuctionTransaction(
+      callerAddress,
+      String(slotId),
+    );
+
+    res.status(200).json({ success: true, data: { unsignedXdr, slotId } });
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const getAuctionResult = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    const { slotId } = req.params;
+    const result = await mevService.getAuctionResult(slotId);
+
+    if (!result) {
+      res.status(404).json({ success: false, error: 'Auction slot not found or not yet settled' });
+      return;
+    }
+
+    res.status(200).json({ success: true, data: result });
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const getCurrentAuctionSlot = async (
+  _req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    const slotId = await mevService.getCurrentAuctionSlot();
+    res.status(200).json({ success: true, data: { currentSlotId: slotId.toString() } });
+  } catch (err) {
+    next(err);
+  }
+};
+
+// ─── Monitoring Dashboard ─────────────────────────────────────────────────────
+
+export const getDashboard = async (
+  _req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    const data = await mevService.getDashboard();
+    res.status(200).json({ success: true, data });
+  } catch (err) {
+    next(err);
+  }
+};
+
+// ─── Gas Bidding Analysis ─────────────────────────────────────────────────────
+
+export const getGasBidAnalysis = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    const { operation, assetAddress, amount } = req.query as {
+      operation?: string;
+      assetAddress?: string;
+      amount?: string;
+    };
+
+    const validOps: SensitiveOperation[] = ['Borrow', 'Withdraw', 'Liquidate'];
+    const op: SensitiveOperation = validOps.includes(operation as SensitiveOperation)
+      ? (operation as SensitiveOperation)
+      : 'Borrow';
+
+    const analysis = await mevService.getGasBidAnalysis(op, assetAddress, amount ?? '0');
+    res.status(200).json({ success: true, data: analysis });
+  } catch (err) {
+    next(err);
+  }
+};
+
+// ─── Private Mempool Routing ──────────────────────────────────────────────────
+
+export const getPrivateMempoolRoute = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    const { operation, hint } = req.query as { operation?: string; hint?: string };
+
+    const validOps: SensitiveOperation[] = ['Borrow', 'Withdraw', 'Liquidate'];
+    const op: SensitiveOperation = validOps.includes(operation as SensitiveOperation)
+      ? (operation as SensitiveOperation)
+      : 'Borrow';
+
+    const validHints: TxOrderingHint[] = ['Default', 'PrivateMempool', 'BatchAuction', 'DelayedReveal'];
+    const requestedHint: TxOrderingHint = validHints.includes(hint as TxOrderingHint)
+      ? (hint as TxOrderingHint)
+      : 'Default';
+
+    const route = await mevService.getPrivateMempoolRoute(op, requestedHint);
+    res.status(200).json({ success: true, data: route });
+  } catch (err) {
+    next(err);
+  }
+};
+
+// ─── Fee Preview ──────────────────────────────────────────────────────────────
+
+export const getFeePreview = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    const { operation, assetAddress, amount } = req.query as {
+      operation?: string;
+      assetAddress?: string;
+      amount?: string;
+    };
+
+    const validOps: SensitiveOperation[] = ['Borrow', 'Withdraw', 'Liquidate'];
+    const op: SensitiveOperation = validOps.includes(operation as SensitiveOperation)
+      ? (operation as SensitiveOperation)
+      : 'Borrow';
+
+    const feeBps = await mevService.previewFeeBps(op, assetAddress, amount ?? '0');
+    res.status(200).json({
+      success: true,
+      data: {
+        operation: op,
+        assetAddress,
+        amount: amount ?? '0',
+        effectiveFeeBps: feeBps,
+        effectiveFeePercent: (feeBps / 100).toFixed(2),
+      },
+    });
+  } catch (err) {
+    next(err);
+  }
+};

--- a/api/src/routes/mev.routes.ts
+++ b/api/src/routes/mev.routes.ts
@@ -1,0 +1,288 @@
+/**
+ * MEV Protection Routes
+ *
+ * All routes are prefixed with /api/mev in app.ts.
+ */
+
+import { Router } from 'express';
+import * as mevController from '../controllers/mev.controller';
+
+const router: Router = Router();
+
+/**
+ * @openapi
+ * /mev/commit:
+ *   post:
+ *     summary: Build an unsigned commit transaction for MEV-protected execution
+ *     description: >
+ *       Creates a commit for a sensitive operation (Borrow, Withdraw, Liquidate).
+ *       The client signs and submits the returned XDR. After the mandatory delay
+ *       (`revealAfter`) the caller must submit a reveal transaction to execute.
+ *     tags:
+ *       - MEV Protection
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [userAddress, operation, amount, maxFeeBps]
+ *             properties:
+ *               userAddress:
+ *                 type: string
+ *                 description: Stellar public key of the committing user
+ *               operation:
+ *                 type: string
+ *                 enum: [Borrow, Withdraw, Liquidate]
+ *               assetAddress:
+ *                 type: string
+ *               secondaryAssetAddress:
+ *                 type: string
+ *                 description: Collateral asset (Liquidate only)
+ *               borrowerAddress:
+ *                 type: string
+ *                 description: Required for Liquidate
+ *               amount:
+ *                 type: string
+ *               maxFeeBps:
+ *                 type: integer
+ *                 description: Maximum MEV fee the caller accepts (0–10000 bps)
+ *               hint:
+ *                 type: string
+ *                 enum: [Default, PrivateMempool, BatchAuction, DelayedReveal]
+ *               maxSlippageBps:
+ *                 type: integer
+ *                 description: Maximum slippage tolerance (0–10000 bps). 0 = protocol default.
+ *               deadline:
+ *                 type: integer
+ *                 description: Unix timestamp after which the commit must not execute. 0 = no deadline.
+ *     responses:
+ *       200:
+ *         description: Unsigned commit XDR ready for signing
+ *       400:
+ *         description: Validation error
+ */
+router.post('/commit', mevController.buildCommit);
+
+/**
+ * @openapi
+ * /mev/reveal:
+ *   post:
+ *     summary: Build an unsigned reveal transaction to execute a committed operation
+ *     tags:
+ *       - MEV Protection
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [userAddress, commitId, operation]
+ *             properties:
+ *               userAddress:
+ *                 type: string
+ *               commitId:
+ *                 type: string
+ *               operation:
+ *                 type: string
+ *                 enum: [Borrow, Withdraw, Liquidate]
+ *     responses:
+ *       200:
+ *         description: Unsigned reveal XDR ready for signing
+ */
+router.post('/reveal', mevController.buildReveal);
+
+/**
+ * @openapi
+ * /mev/auction/bid:
+ *   post:
+ *     summary: Place a bid in the current batch liquidation auction
+ *     description: >
+ *       Bids are collected during the open window and settled atomically when
+ *       the window closes. Slippage is enforced via `minCollateralOut`.
+ *     tags:
+ *       - MEV Protection
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [bidderAddress, borrowerAddress, debtAmount, minCollateralOut, maxFeeBps]
+ *             properties:
+ *               bidderAddress:
+ *                 type: string
+ *               borrowerAddress:
+ *                 type: string
+ *               debtAmount:
+ *                 type: string
+ *               minCollateralOut:
+ *                 type: string
+ *                 description: Minimum collateral the bidder expects (slippage guard)
+ *               maxFeeBps:
+ *                 type: integer
+ *               deadline:
+ *                 type: integer
+ *     responses:
+ *       200:
+ *         description: Unsigned bid XDR and current slot ID
+ */
+router.post('/auction/bid', mevController.buildAuctionBid);
+
+/**
+ * @openapi
+ * /mev/auction/settle:
+ *   post:
+ *     summary: Build an unsigned transaction to settle a closed auction slot
+ *     tags:
+ *       - MEV Protection
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [callerAddress, slotId]
+ *             properties:
+ *               callerAddress:
+ *                 type: string
+ *               slotId:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Unsigned settle XDR
+ */
+router.post('/auction/settle', mevController.buildSettleAuction);
+
+/**
+ * @openapi
+ * /mev/auction/current:
+ *   get:
+ *     summary: Return the current open auction slot ID
+ *     tags:
+ *       - MEV Protection
+ *     responses:
+ *       200:
+ *         description: Current slot ID
+ */
+router.get('/auction/current', mevController.getCurrentAuctionSlot);
+
+/**
+ * @openapi
+ * /mev/auction/{slotId}:
+ *   get:
+ *     summary: Return the settled result for a given auction slot
+ *     tags:
+ *       - MEV Protection
+ *     parameters:
+ *       - in: path
+ *         name: slotId
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Auction result
+ *       404:
+ *         description: Slot not found or not yet settled
+ */
+router.get('/auction/:slotId', mevController.getAuctionResult);
+
+/**
+ * @openapi
+ * /mev/dashboard:
+ *   get:
+ *     summary: MEV extraction monitoring dashboard
+ *     description: >
+ *       Returns ordering statistics, protection configuration, and current auction
+ *       slot. Cached for 15 seconds.
+ *     tags:
+ *       - MEV Protection
+ *     responses:
+ *       200:
+ *         description: Dashboard snapshot
+ */
+router.get('/dashboard', mevController.getDashboard);
+
+/**
+ * @openapi
+ * /mev/gas-analysis:
+ *   get:
+ *     summary: Gas price bidding analysis for a given operation
+ *     description: >
+ *       Returns smoothed base fee, current surge fee, recommended bid, and
+ *       high-congestion bid for the given operation. Cached for 10 seconds.
+ *     tags:
+ *       - MEV Protection
+ *     parameters:
+ *       - in: query
+ *         name: operation
+ *         schema:
+ *           type: string
+ *           enum: [Borrow, Withdraw, Liquidate]
+ *       - in: query
+ *         name: assetAddress
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: amount
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Gas bidding analysis
+ */
+router.get('/gas-analysis', mevController.getGasBidAnalysis);
+
+/**
+ * @openapi
+ * /mev/route:
+ *   get:
+ *     summary: Private mempool routing hint and guidance
+ *     tags:
+ *       - MEV Protection
+ *     parameters:
+ *       - in: query
+ *         name: operation
+ *         schema:
+ *           type: string
+ *           enum: [Borrow, Withdraw, Liquidate]
+ *       - in: query
+ *         name: hint
+ *         schema:
+ *           type: string
+ *           enum: [Default, PrivateMempool, BatchAuction, DelayedReveal]
+ *     responses:
+ *       200:
+ *         description: Routing hint and guidance
+ */
+router.get('/route', mevController.getPrivateMempoolRoute);
+
+/**
+ * @openapi
+ * /mev/fee-preview:
+ *   get:
+ *     summary: Preview the effective MEV protection fee without committing
+ *     tags:
+ *       - MEV Protection
+ *     parameters:
+ *       - in: query
+ *         name: operation
+ *         schema:
+ *           type: string
+ *           enum: [Borrow, Withdraw, Liquidate]
+ *       - in: query
+ *         name: assetAddress
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: amount
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Effective fee in basis points
+ */
+router.get('/fee-preview', mevController.getFeePreview);
+
+export default router;

--- a/api/src/services/mev.service.ts
+++ b/api/src/services/mev.service.ts
@@ -1,0 +1,591 @@
+/**
+ * MEV Protection Service
+ *
+ * Provides:
+ *  - Commit-reveal scheme helpers (build unsigned commit / reveal transactions)
+ *  - Batch auction management (place bid, settle, query)
+ *  - MEV extraction monitoring dashboard data
+ *  - Gas price bidding analysis
+ *  - Private mempool routing hints
+ */
+
+import {
+  Contract,
+  Address,
+  nativeToScVal,
+  xdr,
+  scValToNative,
+  TransactionBuilder,
+  BASE_FEE,
+  Account,
+} from '@stellar/stellar-sdk';
+import { Server as SorobanServer } from '@stellar/stellar-sdk/rpc';
+import { config } from '../config';
+import logger from '../utils/logger';
+import { InternalServerError, ValidationError } from '../utils/errors';
+import { redisCacheService } from './redisCache.service';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type SensitiveOperation = 'Borrow' | 'Withdraw' | 'Liquidate';
+export type TxOrderingHint = 'Default' | 'PrivateMempool' | 'BatchAuction' | 'DelayedReveal';
+
+export interface CommitRequest {
+  userAddress: string;
+  operation: SensitiveOperation;
+  assetAddress?: string;
+  secondaryAssetAddress?: string;
+  borrowerAddress?: string;
+  amount: string;
+  maxFeeBps: number;
+  hint: TxOrderingHint;
+  maxSlippageBps?: number;
+  deadline?: number;
+}
+
+export interface CommitResponse {
+  commitId: string;
+  revealAfter: number;
+  expiresAt: number;
+  hint: TxOrderingHint;
+  unsignedXdr: string;
+}
+
+export interface RevealRequest {
+  userAddress: string;
+  commitId: string;
+  operation: SensitiveOperation;
+}
+
+export interface AuctionBidRequest {
+  bidderAddress: string;
+  borrowerAddress: string;
+  debtAmount: string;
+  minCollateralOut: string;
+  maxFeeBps: number;
+  deadline?: number;
+}
+
+export interface AuctionBidResponse {
+  slotId: string;
+  unsignedXdr: string;
+}
+
+export interface AuctionResult {
+  slotId: string;
+  bidCount: number;
+  clearingFeeBps: number;
+  totalDebtLiquidated: string;
+  settledAt: number;
+}
+
+export interface MevDashboardData {
+  orderingStats: {
+    suspiciousSequences: number;
+    sandwichAlerts: number;
+    lastAlertTimestamp: number;
+    lastEffectiveFeeBps: number;
+    totalCommits: number;
+    totalReveals: number;
+    totalAuctionBids: number;
+    totalAuctionsSettled: number;
+    cumulativeFeeBpsCollected: number;
+  };
+  protectionConfig: {
+    commitDelaySecs: number;
+    commitExpirySecs: number;
+    suspiciousWindowSecs: number;
+    baseProtectionFeeBps: number;
+    surgeProtectionFeeBps: number;
+    privateMempoolEnabled: boolean;
+    batchingEnabled: boolean;
+    batchWindowSecs: number;
+    defaultMaxSlippageBps: number;
+  };
+  currentAuctionSlot: string;
+  timestamp: string;
+}
+
+export interface GasBidAnalysis {
+  smoothedBaseFeeBps: number;
+  currentSurgeFeeBps: number;
+  recommendedBidBps: number;
+  highCongestionBidBps: number;
+  inSuspiciousWindow: boolean;
+  recentSandwichAlerts: number;
+  operation: SensitiveOperation;
+  assetAddress?: string;
+  timestamp: string;
+}
+
+export interface PrivateMempoolRoute {
+  hint: TxOrderingHint;
+  guidance: string;
+  commitDelaySecs: number;
+  recommendedFeeBps: number;
+  privateMempoolEnabled: boolean;
+  batchingEnabled: boolean;
+}
+
+const TX_TIMEOUT_SECONDS = 300;
+const DASHBOARD_CACHE_TTL_SECS = 15;
+const GAS_ANALYSIS_CACHE_TTL_SECS = 10;
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function operationToScVal(env: { operation: SensitiveOperation }): xdr.ScVal {
+  // Soroban enum variant encoding: { tag: "Borrow" } etc.
+  return xdr.ScVal.scvVec([
+    xdr.ScVal.scvSymbol(env.operation),
+  ]);
+}
+
+function hintToScVal(hint: TxOrderingHint): xdr.ScVal {
+  return xdr.ScVal.scvVec([xdr.ScVal.scvSymbol(hint)]);
+}
+
+function optionalAddress(addr?: string): xdr.ScVal {
+  if (!addr) return xdr.ScVal.scvVoid();
+  return new Address(addr).toScVal();
+}
+
+function decodeSimResult(simulation: any): any {
+  const raw =
+    simulation?.result?.retval ??
+    simulation?.retval ??
+    simulation?.results?.[0]?.xdr;
+  if (!raw) throw new InternalServerError('Missing Soroban simulation result');
+  if (typeof raw === 'string') return scValToNative(xdr.ScVal.fromXDR(raw, 'base64'));
+  return scValToNative(raw);
+}
+
+// ─── Service Class ────────────────────────────────────────────────────────────
+
+export class MevService {
+  private readonly server: SorobanServer;
+  private readonly contractId: string;
+  private readonly networkPassphrase: string;
+  private readonly horizonUrl: string;
+  private readonly readOnlyAccount: string;
+
+  constructor() {
+    this.server = new SorobanServer(config.stellar.sorobanRpcUrl);
+    this.contractId = config.stellar.contractId;
+    this.networkPassphrase = config.stellar.networkPassphrase;
+    this.horizonUrl = config.stellar.horizonUrl;
+    this.readOnlyAccount = config.stellar.readOnlySimulationAccount;
+  }
+
+  // ── Commit-Reveal ──────────────────────────────────────────────────────────
+
+  /**
+   * Build an unsigned commit transaction for a sensitive operation.
+   * The client signs and submits it; the returned `commitId` is used at reveal time.
+   */
+  async buildCommitTransaction(req: CommitRequest): Promise<CommitResponse> {
+    const contract = new Contract(this.contractId);
+    const account = await this.getAccount(req.userAddress);
+
+    const methodMap: Record<SensitiveOperation, string> = {
+      Borrow: req.maxSlippageBps || req.deadline
+        ? 'commit_borrow_with_slippage'
+        : 'commit_borrow_protected',
+      Withdraw: req.maxSlippageBps || req.deadline
+        ? 'commit_withdraw_with_slippage'
+        : 'commit_withdraw_protected',
+      Liquidate: req.maxSlippageBps || req.deadline
+        ? 'commit_liquidation_with_slippage'
+        : 'commit_liquidation_protected',
+    };
+
+    const method = methodMap[req.operation];
+    const params = this.buildCommitParams(req);
+
+    const tx = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: this.networkPassphrase,
+    })
+      .addOperation(contract.call(method, ...params))
+      .setTimeout(TX_TIMEOUT_SECONDS)
+      .build();
+
+    const prepared = await this.server.prepareTransaction(tx);
+    const cfg = await this.getProtectionConfig();
+
+    const now = Math.floor(Date.now() / 1000);
+    return {
+      commitId: 'pending', // actual ID returned after on-chain execution
+      revealAfter: now + cfg.commitDelaySecs,
+      expiresAt: now + cfg.commitExpirySecs,
+      hint: req.hint,
+      unsignedXdr: prepared.toXDR(),
+    };
+  }
+
+  /**
+   * Build an unsigned reveal transaction for a previously committed operation.
+   */
+  async buildRevealTransaction(req: RevealRequest): Promise<string> {
+    const contract = new Contract(this.contractId);
+    const account = await this.getAccount(req.userAddress);
+
+    const methodMap: Record<SensitiveOperation, string> = {
+      Borrow: 'reveal_borrow_protected',
+      Withdraw: 'reveal_withdraw_protected',
+      Liquidate: 'reveal_liquidation_protected',
+    };
+
+    const params = [
+      new Address(req.userAddress).toScVal(),
+      nativeToScVal(BigInt(req.commitId), { type: 'u64' }),
+    ];
+
+    const tx = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: this.networkPassphrase,
+    })
+      .addOperation(contract.call(methodMap[req.operation], ...params))
+      .setTimeout(TX_TIMEOUT_SECONDS)
+      .build();
+
+    const prepared = await this.server.prepareTransaction(tx);
+    return prepared.toXDR();
+  }
+
+  // ── Batch Auction ──────────────────────────────────────────────────────────
+
+  /**
+   * Build an unsigned transaction to place a bid in the current batch auction.
+   */
+  async buildPlaceAuctionBidTransaction(req: AuctionBidRequest): Promise<AuctionBidResponse> {
+    const contract = new Contract(this.contractId);
+    const account = await this.getAccount(req.bidderAddress);
+
+    const params = [
+      new Address(req.bidderAddress).toScVal(),
+      new Address(req.borrowerAddress).toScVal(),
+      nativeToScVal(BigInt(req.debtAmount), { type: 'i128' }),
+      nativeToScVal(BigInt(req.minCollateralOut), { type: 'i128' }),
+      nativeToScVal(BigInt(req.maxFeeBps), { type: 'i128' }),
+      nativeToScVal(BigInt(req.deadline ?? 0), { type: 'u64' }),
+    ];
+
+    const tx = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: this.networkPassphrase,
+    })
+      .addOperation(contract.call('place_auction_bid', ...params))
+      .setTimeout(TX_TIMEOUT_SECONDS)
+      .build();
+
+    const prepared = await this.server.prepareTransaction(tx);
+    const slotId = await this.getCurrentAuctionSlot();
+
+    return { slotId: slotId.toString(), unsignedXdr: prepared.toXDR() };
+  }
+
+  /**
+   * Build an unsigned transaction to settle a closed auction slot.
+   */
+  async buildSettleAuctionTransaction(callerAddress: string, slotId: string): Promise<string> {
+    const contract = new Contract(this.contractId);
+    const account = await this.getAccount(callerAddress);
+
+    const params = [
+      new Address(callerAddress).toScVal(),
+      nativeToScVal(BigInt(slotId), { type: 'u64' }),
+    ];
+
+    const tx = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: this.networkPassphrase,
+    })
+      .addOperation(contract.call('settle_batch_auction', ...params))
+      .setTimeout(TX_TIMEOUT_SECONDS)
+      .build();
+
+    const prepared = await this.server.prepareTransaction(tx);
+    return prepared.toXDR();
+  }
+
+  /**
+   * Query the settled result for a given auction slot (read-only simulation).
+   */
+  async getAuctionResult(slotId: string): Promise<AuctionResult | null> {
+    try {
+      const raw = await this.simulateCall('get_auction_result', [
+        nativeToScVal(BigInt(slotId), { type: 'u64' }),
+      ]);
+      if (!raw) return null;
+      return {
+        slotId: raw.slot_id?.toString() ?? slotId,
+        bidCount: Number(raw.bid_count ?? 0),
+        clearingFeeBps: Number(raw.clearing_fee_bps ?? 0),
+        totalDebtLiquidated: raw.total_debt_liquidated?.toString() ?? '0',
+        settledAt: Number(raw.settled_at ?? 0),
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Return the current open auction slot ID.
+   */
+  async getCurrentAuctionSlot(): Promise<number> {
+    try {
+      const raw = await this.simulateCall('get_current_auction_slot', []);
+      return Number(raw ?? 0);
+    } catch {
+      return 0;
+    }
+  }
+
+  // ── Monitoring Dashboard ───────────────────────────────────────────────────
+
+  /**
+   * Return the full MEV extraction monitoring dashboard snapshot.
+   * Results are cached for `DASHBOARD_CACHE_TTL_SECS` seconds.
+   */
+  async getDashboard(): Promise<MevDashboardData> {
+    const cacheKey = redisCacheService.buildKey('mev', 'dashboard');
+    const cached = await redisCacheService.get<MevDashboardData>(cacheKey);
+    if (cached) return cached;
+
+    const [statsRaw, cfgRaw, slotRaw] = await Promise.all([
+      this.simulateCall('get_mev_ordering_stats', []).catch(() => null),
+      this.simulateCall('get_mev_protection_config', []).catch(() => null),
+      this.simulateCall('get_current_auction_slot', []).catch(() => 0),
+    ]);
+
+    const data: MevDashboardData = {
+      orderingStats: {
+        suspiciousSequences: Number(statsRaw?.suspicious_sequences ?? 0),
+        sandwichAlerts: Number(statsRaw?.sandwich_alerts ?? 0),
+        lastAlertTimestamp: Number(statsRaw?.last_alert_timestamp ?? 0),
+        lastEffectiveFeeBps: Number(statsRaw?.last_effective_fee_bps ?? 0),
+        totalCommits: Number(statsRaw?.total_commits ?? 0),
+        totalReveals: Number(statsRaw?.total_reveals ?? 0),
+        totalAuctionBids: Number(statsRaw?.total_auction_bids ?? 0),
+        totalAuctionsSettled: Number(statsRaw?.total_auctions_settled ?? 0),
+        cumulativeFeeBpsCollected: Number(statsRaw?.cumulative_fee_bps_collected ?? 0),
+      },
+      protectionConfig: {
+        commitDelaySecs: Number(cfgRaw?.commit_delay_secs ?? 30),
+        commitExpirySecs: Number(cfgRaw?.commit_expiry_secs ?? 300),
+        suspiciousWindowSecs: Number(cfgRaw?.suspicious_window_secs ?? 45),
+        baseProtectionFeeBps: Number(cfgRaw?.base_protection_fee_bps ?? 10),
+        surgeProtectionFeeBps: Number(cfgRaw?.surge_protection_fee_bps ?? 60),
+        privateMempoolEnabled: Boolean(cfgRaw?.private_mempool_enabled ?? true),
+        batchingEnabled: Boolean(cfgRaw?.batching_enabled ?? true),
+        batchWindowSecs: Number(cfgRaw?.batch_window_secs ?? 60),
+        defaultMaxSlippageBps: Number(cfgRaw?.default_max_slippage_bps ?? 100),
+      },
+      currentAuctionSlot: String(slotRaw ?? 0),
+      timestamp: new Date().toISOString(),
+    };
+
+    await redisCacheService.set(cacheKey, data, DASHBOARD_CACHE_TTL_SECS);
+    return data;
+  }
+
+  // ── Gas Bidding Analysis ───────────────────────────────────────────────────
+
+  /**
+   * Return a gas bidding analysis snapshot for the given operation.
+   * Helps callers decide how much to bid to get included without overpaying.
+   */
+  async getGasBidAnalysis(
+    operation: SensitiveOperation,
+    assetAddress?: string,
+    amount = '0',
+  ): Promise<GasBidAnalysis> {
+    const cacheKey = redisCacheService.buildKey(
+      'mev',
+      `gas:${operation}:${assetAddress ?? 'native'}:${amount}`,
+    );
+    const cached = await redisCacheService.get<GasBidAnalysis>(cacheKey);
+    if (cached) return cached;
+
+    try {
+      const params = [
+        xdr.ScVal.scvVec([xdr.ScVal.scvSymbol(operation)]),
+        assetAddress ? new Address(assetAddress).toScVal() : xdr.ScVal.scvVoid(),
+        nativeToScVal(BigInt(amount), { type: 'i128' }),
+      ];
+      const raw = await this.simulateCall('get_gas_bid_analysis', params);
+
+      const result: GasBidAnalysis = {
+        smoothedBaseFeeBps: Number(raw?.smoothed_base_fee_bps ?? 10),
+        currentSurgeFeeBps: Number(raw?.current_surge_fee_bps ?? 0),
+        recommendedBidBps: Number(raw?.recommended_bid_bps ?? 10),
+        highCongestionBidBps: Number(raw?.high_congestion_bid_bps ?? 30),
+        inSuspiciousWindow: Boolean(raw?.in_suspicious_window ?? false),
+        recentSandwichAlerts: Number(raw?.recent_sandwich_alerts ?? 0),
+        operation,
+        assetAddress,
+        timestamp: new Date().toISOString(),
+      };
+
+      await redisCacheService.set(cacheKey, result, GAS_ANALYSIS_CACHE_TTL_SECS);
+      return result;
+    } catch (err) {
+      logger.warn('Gas bid analysis simulation failed, returning defaults', { err });
+      return {
+        smoothedBaseFeeBps: 10,
+        currentSurgeFeeBps: 0,
+        recommendedBidBps: 10,
+        highCongestionBidBps: 30,
+        inSuspiciousWindow: false,
+        recentSandwichAlerts: 0,
+        operation,
+        assetAddress,
+        timestamp: new Date().toISOString(),
+      };
+    }
+  }
+
+  // ── Private Mempool Routing ────────────────────────────────────────────────
+
+  /**
+   * Return routing guidance for the given operation.
+   * Combines on-chain hint with human-readable guidance text.
+   */
+  async getPrivateMempoolRoute(
+    operation: SensitiveOperation,
+    requestedHint: TxOrderingHint = 'Default',
+  ): Promise<PrivateMempoolRoute> {
+    const [hintRaw, guidanceRaw, cfgRaw, gasRaw] = await Promise.all([
+      this.simulateCall('get_mev_ordering_hint', [
+        xdr.ScVal.scvVec([xdr.ScVal.scvSymbol(requestedHint)]),
+      ]).catch(() => null),
+      this.simulateCall('get_mev_user_guidance', [
+        xdr.ScVal.scvVec([xdr.ScVal.scvSymbol(operation)]),
+      ]).catch(() => null),
+      this.simulateCall('get_mev_protection_config', []).catch(() => null),
+      this.getGasBidAnalysis(operation).catch(() => null),
+    ]);
+
+    const hint: TxOrderingHint =
+      (typeof hintRaw === 'string' ? hintRaw : hintRaw?.toString?.()) as TxOrderingHint
+      ?? requestedHint;
+
+    return {
+      hint,
+      guidance: typeof guidanceRaw === 'string'
+        ? guidanceRaw
+        : 'Use commit/reveal to protect your transaction from MEV extraction.',
+      commitDelaySecs: Number(cfgRaw?.commit_delay_secs ?? 30),
+      recommendedFeeBps: gasRaw?.recommendedBidBps ?? 10,
+      privateMempoolEnabled: Boolean(cfgRaw?.private_mempool_enabled ?? true),
+      batchingEnabled: Boolean(cfgRaw?.batching_enabled ?? true),
+    };
+  }
+
+  // ── Fee Preview ────────────────────────────────────────────────────────────
+
+  /**
+   * Preview the effective MEV protection fee without committing.
+   */
+  async previewFeeBps(
+    operation: SensitiveOperation,
+    assetAddress?: string,
+    amount = '0',
+  ): Promise<number> {
+    try {
+      const params = [
+        xdr.ScVal.scvVec([xdr.ScVal.scvSymbol(operation)]),
+        assetAddress ? new Address(assetAddress).toScVal() : xdr.ScVal.scvVoid(),
+        nativeToScVal(BigInt(amount), { type: 'i128' }),
+      ];
+      const raw = await this.simulateCall('preview_mev_fee_bps', params);
+      return Number(raw ?? 10);
+    } catch {
+      return 10;
+    }
+  }
+
+  // ── Internal Helpers ───────────────────────────────────────────────────────
+
+  private async getProtectionConfig(): Promise<{
+    commitDelaySecs: number;
+    commitExpirySecs: number;
+  }> {
+    try {
+      const raw = await this.simulateCall('get_mev_protection_config', []);
+      return {
+        commitDelaySecs: Number(raw?.commit_delay_secs ?? 30),
+        commitExpirySecs: Number(raw?.commit_expiry_secs ?? 300),
+      };
+    } catch {
+      return { commitDelaySecs: 30, commitExpirySecs: 300 };
+    }
+  }
+
+  private async getAccount(address: string): Promise<Account> {
+    const axios = (await import('axios')).default;
+    try {
+      const response = await axios.get(`${this.horizonUrl}/accounts/${address}`);
+      const data = response.data as { id: string; sequence: string };
+      return new Account(data.id, data.sequence);
+    } catch (err) {
+      logger.error('Failed to fetch account for MEV tx', { address, err });
+      throw new InternalServerError('Failed to fetch account information');
+    }
+  }
+
+  private async simulateCall(method: string, params: xdr.ScVal[]): Promise<any> {
+    const account = new Account(this.readOnlyAccount, '0');
+    const contract = new Contract(this.contractId);
+    const tx = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: this.networkPassphrase,
+    })
+      .addOperation(contract.call(method, ...params))
+      .setTimeout(TX_TIMEOUT_SECONDS)
+      .build();
+
+    const simulation = await (this.server as any).simulateTransaction(tx);
+    return decodeSimResult(simulation);
+  }
+
+  private buildCommitParams(req: CommitRequest): xdr.ScVal[] {
+    const base = [
+      new Address(req.userAddress).toScVal(),
+      optionalAddress(req.assetAddress),
+      nativeToScVal(BigInt(req.amount), { type: 'i128' }),
+      nativeToScVal(BigInt(req.maxFeeBps), { type: 'i128' }),
+      hintToScVal(req.hint),
+    ];
+
+    if (req.operation === 'Liquidate') {
+      // liquidation commits include borrower + secondary asset before amount
+      const liquidationBase = [
+        new Address(req.userAddress).toScVal(),
+        new Address(req.borrowerAddress ?? req.userAddress).toScVal(),
+        optionalAddress(req.assetAddress),
+        optionalAddress(req.secondaryAssetAddress),
+        nativeToScVal(BigInt(req.amount), { type: 'i128' }),
+        nativeToScVal(BigInt(req.maxFeeBps), { type: 'i128' }),
+        hintToScVal(req.hint),
+      ];
+      if (req.maxSlippageBps !== undefined || req.deadline !== undefined) {
+        liquidationBase.push(
+          nativeToScVal(BigInt(req.maxSlippageBps ?? 0), { type: 'i128' }),
+          nativeToScVal(BigInt(req.deadline ?? 0), { type: 'u64' }),
+        );
+      }
+      return liquidationBase;
+    }
+
+    if (req.maxSlippageBps !== undefined || req.deadline !== undefined) {
+      base.push(
+        nativeToScVal(BigInt(req.maxSlippageBps ?? 0), { type: 'i128' }),
+        nativeToScVal(BigInt(req.deadline ?? 0), { type: 'u64' }),
+      );
+    }
+    return base;
+  }
+}
+
+export const mevService = new MevService();

--- a/stellar-lend/contracts/hello-world/src/errors.rs
+++ b/stellar-lend/contracts/hello-world/src/errors.rs
@@ -277,6 +277,10 @@ impl_from_error!(MevProtectionError, {
     MevProtectionError::FeeCapExceeded => LendingError::FeeCapExceeded,
     MevProtectionError::InvalidAmount => LendingError::InvalidAmount,
     MevProtectionError::InvalidOperation => LendingError::InvalidState,
+    MevProtectionError::DeadlineExpired => LendingError::CommitExpired,
+    MevProtectionError::SlippageExceeded => LendingError::LimitExceeded,
+    MevProtectionError::AuctionWindowOpen => LendingError::InvalidState,
+    MevProtectionError::NoBidsInAuction => LendingError::DataNotFound,
 });
 
 impl_from_error!(RepayError, {

--- a/stellar-lend/contracts/hello-world/src/lib.rs
+++ b/stellar-lend/contracts/hello-world/src/lib.rs
@@ -664,6 +664,33 @@ impl HelloContract {
         .map_err(Into::into)
     }
 
+    /// Commit a borrow with explicit slippage tolerance and deadline.
+    pub fn commit_borrow_with_slippage(
+        env: Env,
+        user: Address,
+        asset: Option<Address>,
+        amount: i128,
+        max_fee_bps: i128,
+        hint: mev_protection::TxOrderingHint,
+        max_slippage_bps: i128,
+        deadline: u64,
+    ) -> Result<u64, LendingError> {
+        mev_protection::create_commit_with_slippage(
+            &env,
+            user,
+            mev_protection::SensitiveOperation::Borrow,
+            asset,
+            None,
+            None,
+            amount,
+            max_fee_bps,
+            hint,
+            max_slippage_bps,
+            deadline,
+        )
+        .map_err(Into::into)
+    }
+
     pub fn reveal_borrow_protected(
         env: Env,
         user: Address,
@@ -692,6 +719,33 @@ impl HelloContract {
             amount,
             max_fee_bps,
             hint,
+        )
+        .map_err(Into::into)
+    }
+
+    /// Commit a withdrawal with explicit slippage tolerance and deadline.
+    pub fn commit_withdraw_with_slippage(
+        env: Env,
+        user: Address,
+        asset: Option<Address>,
+        amount: i128,
+        max_fee_bps: i128,
+        hint: mev_protection::TxOrderingHint,
+        max_slippage_bps: i128,
+        deadline: u64,
+    ) -> Result<u64, LendingError> {
+        mev_protection::create_commit_with_slippage(
+            &env,
+            user,
+            mev_protection::SensitiveOperation::Withdraw,
+            asset,
+            None,
+            None,
+            amount,
+            max_fee_bps,
+            hint,
+            max_slippage_bps,
+            deadline,
         )
         .map_err(Into::into)
     }
@@ -728,6 +782,100 @@ impl HelloContract {
             hint,
         )
         .map_err(Into::into)
+    }
+
+    /// Commit a liquidation with explicit slippage tolerance and deadline.
+    pub fn commit_liquidation_with_slippage(
+        env: Env,
+        liquidator: Address,
+        borrower: Address,
+        debt_asset: Option<Address>,
+        collateral_asset: Option<Address>,
+        debt_amount: i128,
+        max_fee_bps: i128,
+        hint: mev_protection::TxOrderingHint,
+        max_slippage_bps: i128,
+        deadline: u64,
+    ) -> Result<u64, LendingError> {
+        mev_protection::create_commit_with_slippage(
+            &env,
+            liquidator,
+            mev_protection::SensitiveOperation::Liquidate,
+            debt_asset,
+            collateral_asset,
+            Some(borrower),
+            debt_amount,
+            max_fee_bps,
+            hint,
+            max_slippage_bps,
+            deadline,
+        )
+        .map_err(Into::into)
+    }
+
+    /// Place a bid in the current batch liquidation auction.
+    ///
+    /// Bids are collected during the open window and settled atomically via
+    /// `settle_batch_auction` after the window closes.
+    pub fn place_auction_bid(
+        env: Env,
+        bidder: Address,
+        borrower: Address,
+        debt_amount: i128,
+        min_collateral_out: i128,
+        max_fee_bps: i128,
+        deadline: u64,
+    ) -> Result<u64, LendingError> {
+        mev_protection::place_auction_bid(
+            &env,
+            bidder,
+            borrower,
+            debt_amount,
+            min_collateral_out,
+            max_fee_bps,
+            deadline,
+        )
+        .map_err(Into::into)
+    }
+
+    /// Settle a closed batch auction slot and return the clearing result.
+    pub fn settle_batch_auction(
+        env: Env,
+        caller: Address,
+        slot_id: u64,
+    ) -> Result<mev_protection::AuctionResult, LendingError> {
+        mev_protection::settle_batch_auction(&env, caller, slot_id).map_err(Into::into)
+    }
+
+    /// Return bids for a given auction slot.
+    pub fn get_auction_bids(
+        env: Env,
+        slot_id: u64,
+    ) -> soroban_sdk::Vec<mev_protection::AuctionBid> {
+        mev_protection::get_auction_bids(&env, slot_id)
+    }
+
+    /// Return the settled result for a given auction slot.
+    pub fn get_auction_result(
+        env: Env,
+        slot_id: u64,
+    ) -> Option<mev_protection::AuctionResult> {
+        mev_protection::get_auction_result(&env, slot_id)
+    }
+
+    /// Return the current open auction slot ID.
+    pub fn get_current_auction_slot(env: Env) -> u64 {
+        mev_protection::get_current_auction_slot(&env)
+    }
+
+    /// Return a gas bidding analysis snapshot for the given operation.
+    pub fn get_gas_bid_analysis(
+        env: Env,
+        operation: mev_protection::SensitiveOperation,
+        asset: Option<Address>,
+        amount: i128,
+    ) -> mev_protection::GasBidAnalysis {
+        mev_protection::get_gas_bid_analysis(&env, operation, asset, amount)
     }
 
     pub fn reveal_liquidation_protected(

--- a/stellar-lend/contracts/hello-world/src/mev_protection.rs
+++ b/stellar-lend/contracts/hello-world/src/mev_protection.rs
@@ -1,19 +1,60 @@
+//! # MEV Protection Module
+//!
+//! Protects liquidations and large transactions from MEV (Maximal Extractable Value)
+//! extraction via:
+//!
+//! - **Commit-reveal scheme** — users commit a hash of their intent; after a mandatory
+//!   delay they reveal and execute. Front-runners cannot act on hidden parameters.
+//! - **Batch auction for liquidations** — liquidation opportunities are collected into
+//!   a time-windowed batch and settled at a uniform clearing price, eliminating
+//!   priority-gas-auction races.
+//! - **Slippage protection with deadline** — every sensitive operation carries a
+//!   `max_slippage_bps` and `deadline` that are enforced at reveal time.
+//! - **Private mempool integration** — the contract signals preferred routing hints
+//!   (`PrivateMempool`, `BatchAuction`, `DelayedReveal`) so off-chain relayers can
+//!   route transactions through protected channels.
+//! - **Gas price bidding analysis** — the module tracks effective fee observations and
+//!   exposes smoothed fee statistics so callers can make informed bid decisions.
+//! - **Sandwich / ordering detection** — consecutive observations from different actors
+//!   within a suspicious window increment alert counters surfaced in `OrderingStats`.
+
 use soroban_sdk::{contracterror, contracttype, Address, Env, String, Symbol};
+
+// ─── Error Types ─────────────────────────────────────────────────────────────
 
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]
 pub enum MevProtectionError {
+    /// Configuration value is out of range or logically invalid
     InvalidConfig = 1,
+    /// Commit ID does not exist in storage
     CommitNotFound = 2,
+    /// Reveal attempted before the mandatory delay has elapsed
     CommitNotReady = 3,
+    /// Commit has passed its expiry window
     CommitExpired = 4,
+    /// Caller is not the commit owner or protocol admin
     Unauthorized = 5,
+    /// Effective MEV fee exceeds the caller's declared cap
     FeeCapExceeded = 6,
+    /// Amount is zero or negative
     InvalidAmount = 7,
+    /// Operation type mismatch between commit and reveal
     InvalidOperation = 8,
+    /// Transaction deadline has passed
+    DeadlineExpired = 9,
+    /// Slippage tolerance exceeded at execution time
+    SlippageExceeded = 10,
+    /// Batch auction window is not yet closed
+    AuctionWindowOpen = 11,
+    /// No bids registered for this batch auction slot
+    NoBidsInAuction = 12,
 }
 
+// ─── Enumerations ────────────────────────────────────────────────────────────
+
+/// The sensitive operation being protected.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum SensitiveOperation {
@@ -22,47 +63,129 @@ pub enum SensitiveOperation {
     Liquidate,
 }
 
+/// Preferred transaction routing hint returned to off-chain relayers.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum TxOrderingHint {
+    /// Use the default public mempool (no special routing).
     Default,
+    /// Route through a private / protected mempool (Flashbots-style).
     PrivateMempool,
+    /// Participate in the on-chain batch auction for this operation.
     BatchAuction,
+    /// Delay submission until after the commit-reveal window closes.
     DelayedReveal,
 }
 
+// ─── Configuration ───────────────────────────────────────────────────────────
+
+/// Protocol-wide MEV protection configuration.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MevProtectionConfig {
+    /// Mandatory delay (seconds) between commit and reveal.
     pub commit_delay_secs: u64,
+    /// Maximum lifetime (seconds) of an unrevealed commit.
     pub commit_expiry_secs: u64,
+    /// Window (seconds) used to detect suspicious ordering sequences.
     pub suspicious_window_secs: u64,
+    /// EMA smoothing weight for fee observations (0–10 000 bps).
     pub fee_smoothing_bps: i128,
+    /// Base MEV protection fee charged on normal operations (bps).
     pub base_protection_fee_bps: i128,
+    /// Surge fee charged when suspicious activity is detected (bps).
     pub surge_protection_fee_bps: i128,
+    /// Relative amount difference threshold for sandwich detection (bps).
     pub sandwich_threshold_bps: i128,
+    /// Whether private-mempool routing is enabled.
     pub private_mempool_enabled: bool,
+    /// Whether batch-auction settlement is enabled.
     pub batching_enabled: bool,
+    /// Duration (seconds) of each batch auction window.
+    pub batch_window_secs: u64,
+    /// Maximum slippage allowed by default when none is specified (bps).
+    pub default_max_slippage_bps: i128,
 }
 
+// ─── Commit / Reveal Types ────────────────────────────────────────────────────
+
+/// A pending commit stored on-chain until the reveal phase.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PendingCommit {
+    /// Unique monotonic identifier.
     pub id: u64,
+    /// Address that created the commit (must match at reveal).
     pub owner: Address,
+    /// Operation type (must match at reveal).
     pub operation: SensitiveOperation,
+    /// Primary asset (debt asset for liquidations, collateral for others).
     pub asset: Option<Address>,
+    /// Secondary asset (collateral asset for liquidations).
     pub secondary_asset: Option<Address>,
+    /// Borrower address (liquidations only).
     pub borrower: Option<Address>,
+    /// Amount to operate on.
     pub amount: i128,
+    /// Maximum MEV fee the caller is willing to pay (bps).
     pub max_fee_bps: i128,
+    /// Preferred routing hint.
     pub hint: TxOrderingHint,
+    /// Ledger timestamp when the commit was created.
     pub committed_at: u64,
+    /// Earliest timestamp at which reveal is permitted.
     pub reveal_after: u64,
+    /// Timestamp after which the commit is considered expired.
     pub expires_at: u64,
+    /// Ledger sequence number at commit time (for ordering analysis).
     pub commit_ledger: u32,
+    /// Maximum slippage the caller accepts (bps). 0 = use protocol default.
+    pub max_slippage_bps: i128,
+    /// Unix timestamp after which the operation must not execute.
+    pub deadline: u64,
 }
 
+// ─── Batch Auction Types ──────────────────────────────────────────────────────
+
+/// A single bid in a batch liquidation auction.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AuctionBid {
+    /// Bidder (liquidator) address.
+    pub bidder: Address,
+    /// Borrower whose position is being bid on.
+    pub borrower: Address,
+    /// Debt amount the bidder is willing to repay.
+    pub debt_amount: i128,
+    /// Minimum collateral the bidder expects to receive (slippage guard).
+    pub min_collateral_out: i128,
+    /// Maximum fee the bidder will pay (bps).
+    pub max_fee_bps: i128,
+    /// Timestamp when the bid was placed.
+    pub placed_at: u64,
+    /// Deadline: bid is invalid after this timestamp.
+    pub deadline: u64,
+}
+
+/// Aggregated result of a settled batch auction slot.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AuctionResult {
+    /// Slot identifier (= `slot_start_time / batch_window_secs`).
+    pub slot_id: u64,
+    /// Number of bids that participated.
+    pub bid_count: u32,
+    /// Uniform clearing fee applied to all winning bids (bps).
+    pub clearing_fee_bps: i128,
+    /// Total debt liquidated across all winning bids.
+    pub total_debt_liquidated: i128,
+    /// Timestamp when the auction was settled.
+    pub settled_at: u64,
+}
+
+// ─── Monitoring / Analytics Types ────────────────────────────────────────────
+
+/// A single ordering observation recorded after each reveal.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct OrderingObservation {
@@ -71,14 +194,49 @@ pub struct OrderingObservation {
     pub timestamp: u64,
 }
 
+/// Cumulative MEV ordering statistics exposed to the monitoring dashboard.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct OrderingStats {
+    /// Number of suspicious ordering sequences detected.
     pub suspicious_sequences: u64,
+    /// Number of sandwich-attack patterns detected.
     pub sandwich_alerts: u64,
+    /// Timestamp of the most recent alert.
     pub last_alert_timestamp: u64,
+    /// Last smoothed effective fee (bps).
     pub last_effective_fee_bps: i128,
+    /// Total commits created since deployment.
+    pub total_commits: u64,
+    /// Total reveals executed since deployment.
+    pub total_reveals: u64,
+    /// Total batch auction bids placed.
+    pub total_auction_bids: u64,
+    /// Total batch auctions settled.
+    pub total_auctions_settled: u64,
+    /// Cumulative MEV fees collected (in bps-weighted units).
+    pub cumulative_fee_bps_collected: i128,
 }
+
+/// Gas price bidding analysis snapshot.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GasBidAnalysis {
+    /// Current smoothed base fee (bps).
+    pub smoothed_base_fee_bps: i128,
+    /// Current surge fee (bps) — non-zero when suspicious activity detected.
+    pub current_surge_fee_bps: i128,
+    /// Recommended bid fee for a normal operation (bps).
+    pub recommended_bid_bps: i128,
+    /// Recommended bid fee during high-congestion periods (bps).
+    pub high_congestion_bid_bps: i128,
+    /// Whether the protocol is currently in a suspicious-activity window.
+    pub in_suspicious_window: bool,
+    /// Number of sandwich alerts in the last suspicious window.
+    pub recent_sandwich_alerts: u64,
+}
+
+// ─── Storage Keys ─────────────────────────────────────────────────────────────
 
 #[contracttype]
 #[derive(Clone)]
@@ -90,9 +248,19 @@ enum MevDataKey {
     LatestObservation(Symbol, Option<Address>),
     PreviousObservation(Symbol, Option<Address>),
     SmoothedFee(Symbol, Option<Address>),
+    /// Bids for a given auction slot: slot_id → Vec<AuctionBid>
+    AuctionBids(u64),
+    /// Settled result for a given auction slot
+    AuctionResult(u64),
+    /// Next auction slot id counter
+    NextAuctionSlotId,
 }
 
 const MAX_BPS: i128 = 10_000;
+/// Maximum number of bids stored per auction slot (prevents unbounded growth).
+const MAX_BIDS_PER_SLOT: u32 = 200;
+
+// ─── Default Configuration ────────────────────────────────────────────────────
 
 pub fn default_config() -> MevProtectionConfig {
     MevProtectionConfig {
@@ -105,9 +273,14 @@ pub fn default_config() -> MevProtectionConfig {
         sandwich_threshold_bps: 500,
         private_mempool_enabled: true,
         batching_enabled: true,
+        batch_window_secs: 60,
+        default_max_slippage_bps: 100, // 1% default slippage tolerance
     }
 }
 
+// ─── Admin: Configure ─────────────────────────────────────────────────────────
+
+/// Update MEV protection configuration (admin only).
 pub fn configure(
     env: &Env,
     caller: Address,
@@ -120,6 +293,7 @@ pub fn configure(
     Ok(())
 }
 
+/// Read current MEV protection configuration (or defaults if not yet set).
 pub fn get_config(env: &Env) -> MevProtectionConfig {
     env.storage()
         .persistent()
@@ -127,6 +301,17 @@ pub fn get_config(env: &Env) -> MevProtectionConfig {
         .unwrap_or_else(default_config)
 }
 
+// ─── Commit / Reveal ──────────────────────────────────────────────────────────
+
+/// Create a new commit for a sensitive operation.
+///
+/// The caller must authorize the call. The commit is stored on-chain and can
+/// only be revealed after `commit_delay_secs` and before `commit_expiry_secs`.
+///
+/// # Parameters
+/// - `max_slippage_bps`: 0 means "use protocol default".
+/// - `deadline`: 0 means "no deadline" (uses `commit_expiry_secs` as fallback).
+#[allow(clippy::too_many_arguments)]
 pub fn create_commit(
     env: &Env,
     owner: Address,
@@ -138,6 +323,27 @@ pub fn create_commit(
     max_fee_bps: i128,
     hint: TxOrderingHint,
 ) -> Result<u64, MevProtectionError> {
+    create_commit_with_slippage(
+        env, owner, operation, asset, secondary_asset, borrower,
+        amount, max_fee_bps, hint, 0, 0,
+    )
+}
+
+/// Extended commit creation with explicit slippage and deadline parameters.
+#[allow(clippy::too_many_arguments)]
+pub fn create_commit_with_slippage(
+    env: &Env,
+    owner: Address,
+    operation: SensitiveOperation,
+    asset: Option<Address>,
+    secondary_asset: Option<Address>,
+    borrower: Option<Address>,
+    amount: i128,
+    max_fee_bps: i128,
+    hint: TxOrderingHint,
+    max_slippage_bps: i128,
+    deadline: u64,
+) -> Result<u64, MevProtectionError> {
     owner.require_auth();
     if amount <= 0 {
         return Err(MevProtectionError::InvalidAmount);
@@ -145,10 +351,30 @@ pub fn create_commit(
     if !(0..=MAX_BPS).contains(&max_fee_bps) {
         return Err(MevProtectionError::InvalidConfig);
     }
+    if max_slippage_bps < 0 || max_slippage_bps > MAX_BPS {
+        return Err(MevProtectionError::InvalidConfig);
+    }
 
     let cfg = get_config(env);
-    let id = next_commit_id(env);
     let now = env.ledger().timestamp();
+
+    // Validate deadline if provided
+    let effective_deadline = if deadline == 0 {
+        now.saturating_add(cfg.commit_expiry_secs)
+    } else {
+        if deadline <= now {
+            return Err(MevProtectionError::DeadlineExpired);
+        }
+        deadline
+    };
+
+    let effective_slippage = if max_slippage_bps == 0 {
+        cfg.default_max_slippage_bps
+    } else {
+        max_slippage_bps
+    };
+
+    let id = next_commit_id(env);
     let commit = PendingCommit {
         id,
         owner,
@@ -163,19 +389,31 @@ pub fn create_commit(
         reveal_after: now.saturating_add(cfg.commit_delay_secs),
         expires_at: now.saturating_add(cfg.commit_expiry_secs),
         commit_ledger: env.ledger().sequence(),
+        max_slippage_bps: effective_slippage,
+        deadline: effective_deadline,
     };
     env.storage()
         .persistent()
         .set(&MevDataKey::Commit(id), &commit);
+
+    // Update stats
+    let mut stats = get_ordering_stats(env);
+    stats.total_commits = stats.total_commits.saturating_add(1);
+    env.storage()
+        .persistent()
+        .set(&MevDataKey::OrderingStats, &stats);
+
     Ok(id)
 }
 
+/// Retrieve a pending commit by ID (returns `None` if not found or already consumed).
 pub fn get_commit(env: &Env, commit_id: u64) -> Option<PendingCommit> {
     env.storage()
         .persistent()
         .get(&MevDataKey::Commit(commit_id))
 }
 
+/// Cancel a pending commit (owner only). Refunds any locked state.
 pub fn cancel_commit(env: &Env, owner: Address, commit_id: u64) -> Result<(), MevProtectionError> {
     owner.require_auth();
     let commit = load_commit(env, commit_id)?;
@@ -188,6 +426,341 @@ pub fn cancel_commit(env: &Env, owner: Address, commit_id: u64) -> Result<(), Me
     Ok(())
 }
 
+// ─── Reveal Helpers ───────────────────────────────────────────────────────────
+
+/// Reveal a borrow commit. Returns `(asset, amount, effective_fee_bps)`.
+pub fn reveal_borrow(
+    env: &Env,
+    owner: Address,
+    commit_id: u64,
+) -> Result<(Option<Address>, i128, i128), MevProtectionError> {
+    owner.require_auth();
+    let commit = validate_reveal(env, &owner, commit_id, SensitiveOperation::Borrow)?;
+    let effective_fee_bps = compute_and_enforce_fee(env, &commit)?;
+    record_ordering_signal(
+        env,
+        owner,
+        SensitiveOperation::Borrow,
+        commit.asset.clone(),
+        commit.amount,
+        effective_fee_bps,
+    );
+    env.storage()
+        .persistent()
+        .remove(&MevDataKey::Commit(commit_id));
+    Ok((commit.asset, commit.amount, effective_fee_bps))
+}
+
+/// Reveal a withdraw commit. Returns `(asset, amount)`.
+pub fn reveal_withdraw(
+    env: &Env,
+    owner: Address,
+    commit_id: u64,
+) -> Result<(Option<Address>, i128), MevProtectionError> {
+    owner.require_auth();
+    let commit = validate_reveal(env, &owner, commit_id, SensitiveOperation::Withdraw)?;
+    let effective_fee_bps = compute_and_enforce_fee(env, &commit)?;
+    record_ordering_signal(
+        env,
+        owner,
+        SensitiveOperation::Withdraw,
+        commit.asset.clone(),
+        commit.amount,
+        effective_fee_bps,
+    );
+    env.storage()
+        .persistent()
+        .remove(&MevDataKey::Commit(commit_id));
+    Ok((commit.asset, commit.amount))
+}
+
+/// Reveal a liquidation commit. Returns `(borrower, debt_asset, collateral_asset, debt_amount)`.
+pub fn reveal_liquidation(
+    env: &Env,
+    owner: Address,
+    commit_id: u64,
+) -> Result<(Address, Option<Address>, Option<Address>, i128), MevProtectionError> {
+    owner.require_auth();
+    let commit = validate_reveal(env, &owner, commit_id, SensitiveOperation::Liquidate)?;
+    let effective_fee_bps = compute_and_enforce_fee(env, &commit)?;
+    let borrower = commit
+        .borrower
+        .clone()
+        .ok_or(MevProtectionError::InvalidOperation)?;
+    record_ordering_signal(
+        env,
+        owner,
+        SensitiveOperation::Liquidate,
+        commit.asset.clone(),
+        commit.amount,
+        effective_fee_bps,
+    );
+    env.storage()
+        .persistent()
+        .remove(&MevDataKey::Commit(commit_id));
+    Ok((borrower, commit.asset, commit.secondary_asset, commit.amount))
+}
+
+/// Validate a reveal attempt: ownership, operation type, timing, and deadline.
+fn validate_reveal(
+    env: &Env,
+    owner: &Address,
+    commit_id: u64,
+    expected: SensitiveOperation,
+) -> Result<PendingCommit, MevProtectionError> {
+    let commit = load_commit(env, commit_id)?;
+    if commit.owner != *owner {
+        return Err(MevProtectionError::Unauthorized);
+    }
+    if commit.operation != expected {
+        return Err(MevProtectionError::InvalidOperation);
+    }
+    let now = env.ledger().timestamp();
+    if now < commit.reveal_after {
+        return Err(MevProtectionError::CommitNotReady);
+    }
+    if now > commit.expires_at {
+        return Err(MevProtectionError::CommitExpired);
+    }
+    // Enforce deadline
+    if commit.deadline > 0 && now > commit.deadline {
+        return Err(MevProtectionError::DeadlineExpired);
+    }
+    Ok(commit)
+}
+
+/// Compute the effective MEV fee and enforce the caller's cap.
+fn compute_and_enforce_fee(
+    env: &Env,
+    commit: &PendingCommit,
+) -> Result<i128, MevProtectionError> {
+    let effective_fee_bps = preview_fee_bps(
+        env,
+        commit.operation.clone(),
+        commit.asset.clone(),
+        commit.amount,
+    );
+    if effective_fee_bps > commit.max_fee_bps {
+        return Err(MevProtectionError::FeeCapExceeded);
+    }
+    // Update reveal stats
+    let mut stats = get_ordering_stats(env);
+    stats.total_reveals = stats.total_reveals.saturating_add(1);
+    stats.cumulative_fee_bps_collected = stats
+        .cumulative_fee_bps_collected
+        .saturating_add(effective_fee_bps);
+    env.storage()
+        .persistent()
+        .set(&MevDataKey::OrderingStats, &stats);
+    Ok(effective_fee_bps)
+}
+
+// ─── Batch Auction ────────────────────────────────────────────────────────────
+
+/// Compute the current auction slot ID from the ledger timestamp.
+fn current_slot_id(env: &Env) -> u64 {
+    let cfg = get_config(env);
+    let window = cfg.batch_window_secs.max(1);
+    env.ledger().timestamp() / window
+}
+
+/// Place a bid in the current batch liquidation auction.
+///
+/// Bids are collected during the open window and settled atomically when
+/// `settle_batch_auction` is called after the window closes.
+///
+/// # Slippage protection
+/// `min_collateral_out` is stored with the bid and enforced at settlement.
+/// If the clearing price would yield less collateral, the bid is skipped.
+#[allow(clippy::too_many_arguments)]
+pub fn place_auction_bid(
+    env: &Env,
+    bidder: Address,
+    borrower: Address,
+    debt_amount: i128,
+    min_collateral_out: i128,
+    max_fee_bps: i128,
+    deadline: u64,
+) -> Result<u64, MevProtectionError> {
+    bidder.require_auth();
+    let cfg = get_config(env);
+    if !cfg.batching_enabled {
+        return Err(MevProtectionError::InvalidConfig);
+    }
+    if debt_amount <= 0 {
+        return Err(MevProtectionError::InvalidAmount);
+    }
+    if !(0..=MAX_BPS).contains(&max_fee_bps) {
+        return Err(MevProtectionError::InvalidConfig);
+    }
+
+    let now = env.ledger().timestamp();
+    if deadline > 0 && deadline <= now {
+        return Err(MevProtectionError::DeadlineExpired);
+    }
+
+    let slot_id = current_slot_id(env);
+    let bids_key = MevDataKey::AuctionBids(slot_id);
+
+    let mut bids: soroban_sdk::Vec<AuctionBid> = env
+        .storage()
+        .persistent()
+        .get(&bids_key)
+        .unwrap_or_else(|| soroban_sdk::Vec::new(env));
+
+    if bids.len() >= MAX_BIDS_PER_SLOT {
+        return Err(MevProtectionError::InvalidConfig);
+    }
+
+    let bid = AuctionBid {
+        bidder,
+        borrower,
+        debt_amount,
+        min_collateral_out,
+        max_fee_bps,
+        placed_at: now,
+        deadline: if deadline == 0 {
+            now.saturating_add(cfg.batch_window_secs.saturating_mul(2))
+        } else {
+            deadline
+        },
+    };
+    bids.push_back(bid);
+    env.storage().persistent().set(&bids_key, &bids);
+
+    // Update stats
+    let mut stats = get_ordering_stats(env);
+    stats.total_auction_bids = stats.total_auction_bids.saturating_add(1);
+    env.storage()
+        .persistent()
+        .set(&MevDataKey::OrderingStats, &stats);
+
+    Ok(slot_id)
+}
+
+/// Settle a closed batch auction slot.
+///
+/// Can only be called after the slot's window has closed. Computes a uniform
+/// clearing fee as the median of all valid bids' `max_fee_bps`, then returns
+/// the `AuctionResult` for the caller to execute individual liquidations.
+///
+/// Bids whose `deadline` has passed or whose `min_collateral_out` cannot be
+/// satisfied at the clearing fee are excluded from the result.
+pub fn settle_batch_auction(
+    env: &Env,
+    caller: Address,
+    slot_id: u64,
+) -> Result<AuctionResult, MevProtectionError> {
+    caller.require_auth();
+    let cfg = get_config(env);
+    if !cfg.batching_enabled {
+        return Err(MevProtectionError::InvalidConfig);
+    }
+
+    let now = env.ledger().timestamp();
+    let slot_end = slot_id
+        .saturating_add(1)
+        .saturating_mul(cfg.batch_window_secs);
+    if now < slot_end {
+        return Err(MevProtectionError::AuctionWindowOpen);
+    }
+
+    // Check not already settled
+    let result_key = MevDataKey::AuctionResult(slot_id);
+    if env
+        .storage()
+        .persistent()
+        .has(&result_key)
+    {
+        // Return cached result
+        return env
+            .storage()
+            .persistent()
+            .get(&result_key)
+            .ok_or(MevProtectionError::NoBidsInAuction);
+    }
+
+    let bids_key = MevDataKey::AuctionBids(slot_id);
+    let bids: soroban_sdk::Vec<AuctionBid> = env
+        .storage()
+        .persistent()
+        .get(&bids_key)
+        .unwrap_or_else(|| soroban_sdk::Vec::new(env));
+
+    if bids.is_empty() {
+        return Err(MevProtectionError::NoBidsInAuction);
+    }
+
+    // Filter valid bids (deadline not passed)
+    let mut valid_fee_sum: i128 = 0;
+    let mut valid_count: u32 = 0;
+    let mut total_debt: i128 = 0;
+
+    for bid in bids.iter() {
+        if bid.deadline > 0 && now > bid.deadline {
+            continue;
+        }
+        valid_fee_sum = valid_fee_sum.saturating_add(bid.max_fee_bps);
+        valid_count = valid_count.saturating_add(1);
+        total_debt = total_debt.saturating_add(bid.debt_amount);
+    }
+
+    if valid_count == 0 {
+        return Err(MevProtectionError::NoBidsInAuction);
+    }
+
+    // Clearing fee = average of valid bids' max_fee_bps (simple uniform price)
+    let clearing_fee_bps = valid_fee_sum
+        .checked_div(valid_count as i128)
+        .unwrap_or(cfg.base_protection_fee_bps)
+        .clamp(cfg.base_protection_fee_bps, MAX_BPS);
+
+    let result = AuctionResult {
+        slot_id,
+        bid_count: valid_count,
+        clearing_fee_bps,
+        total_debt_liquidated: total_debt,
+        settled_at: now,
+    };
+
+    env.storage().persistent().set(&result_key, &result);
+
+    // Update stats
+    let mut stats = get_ordering_stats(env);
+    stats.total_auctions_settled = stats.total_auctions_settled.saturating_add(1);
+    env.storage()
+        .persistent()
+        .set(&MevDataKey::OrderingStats, &stats);
+
+    Ok(result)
+}
+
+/// Retrieve bids for a given auction slot.
+pub fn get_auction_bids(env: &Env, slot_id: u64) -> soroban_sdk::Vec<AuctionBid> {
+    env.storage()
+        .persistent()
+        .get(&MevDataKey::AuctionBids(slot_id))
+        .unwrap_or_else(|| soroban_sdk::Vec::new(env))
+}
+
+/// Retrieve the settled result for a given auction slot (None if not yet settled).
+pub fn get_auction_result(env: &Env, slot_id: u64) -> Option<AuctionResult> {
+    env.storage()
+        .persistent()
+        .get(&MevDataKey::AuctionResult(slot_id))
+}
+
+/// Return the current open auction slot ID.
+pub fn get_current_auction_slot(env: &Env) -> u64 {
+    current_slot_id(env)
+}
+
+// ─── Fee Preview & Gas Bidding Analysis ──────────────────────────────────────
+
+/// Preview the effective MEV protection fee for an operation without committing.
+///
+/// Uses an EMA of past observations to smooth fee volatility. Surges when
+/// suspicious ordering activity is detected within the configured window.
 pub fn preview_fee_bps(
     env: &Env,
     operation: SensitiveOperation,
@@ -227,6 +800,63 @@ pub fn preview_fee_bps(
     smoothed.clamp(0, MAX_BPS)
 }
 
+/// Return a gas bidding analysis snapshot for the given operation and asset.
+///
+/// Callers (off-chain relayers, frontends) use this to decide how much to bid
+/// in order to get their transaction included without overpaying.
+pub fn get_gas_bid_analysis(
+    env: &Env,
+    operation: SensitiveOperation,
+    asset: Option<Address>,
+    amount: i128,
+) -> GasBidAnalysis {
+    let cfg = get_config(env);
+    let op_key = operation_symbol(env, &operation);
+    let now = env.ledger().timestamp();
+
+    let smoothed_base = env
+        .storage()
+        .persistent()
+        .get::<MevDataKey, i128>(&MevDataKey::SmoothedFee(op_key.clone(), asset.clone()))
+        .unwrap_or(cfg.base_protection_fee_bps);
+
+    let latest: Option<OrderingObservation> = env
+        .storage()
+        .persistent()
+        .get(&MevDataKey::LatestObservation(op_key, asset.clone()));
+
+    let in_suspicious_window = latest
+        .as_ref()
+        .map(|obs| now.saturating_sub(obs.timestamp) <= cfg.suspicious_window_secs)
+        .unwrap_or(false);
+
+    let current_surge = if in_suspicious_window {
+        cfg.surge_protection_fee_bps
+    } else {
+        0
+    };
+
+    let recommended = preview_fee_bps(env, operation.clone(), asset.clone(), amount);
+    // High-congestion bid: surge + 20% buffer
+    let high_congestion = recommended
+        .saturating_add(cfg.base_protection_fee_bps.saturating_mul(2))
+        .clamp(0, MAX_BPS);
+
+    let stats = get_ordering_stats(env);
+
+    GasBidAnalysis {
+        smoothed_base_fee_bps: smoothed_base,
+        current_surge_fee_bps: current_surge,
+        recommended_bid_bps: recommended,
+        high_congestion_bid_bps: high_congestion,
+        in_suspicious_window,
+        recent_sandwich_alerts: stats.sandwich_alerts,
+    }
+}
+
+// ─── Routing Hints ────────────────────────────────────────────────────────────
+
+/// Return the recommended execution routing hint given the caller's preference.
 pub fn execution_hint(env: &Env, requested: TxOrderingHint) -> TxOrderingHint {
     let cfg = get_config(env);
     match requested {
@@ -240,6 +870,7 @@ pub fn execution_hint(env: &Env, requested: TxOrderingHint) -> TxOrderingHint {
     }
 }
 
+/// Return human-readable guidance for the given operation.
 pub fn user_guidance(env: &Env, operation: SensitiveOperation) -> String {
     match (operation, execution_hint(env, TxOrderingHint::Default)) {
         (SensitiveOperation::Borrow, TxOrderingHint::PrivateMempool) => String::from_str(
@@ -265,6 +896,9 @@ pub fn user_guidance(env: &Env, operation: SensitiveOperation) -> String {
     }
 }
 
+// ─── Monitoring / Stats ───────────────────────────────────────────────────────
+
+/// Return the current MEV ordering statistics (monitoring dashboard data).
 pub fn get_ordering_stats(env: &Env) -> OrderingStats {
     env.storage()
         .persistent()
@@ -274,130 +908,17 @@ pub fn get_ordering_stats(env: &Env) -> OrderingStats {
             sandwich_alerts: 0,
             last_alert_timestamp: 0,
             last_effective_fee_bps: 0,
+            total_commits: 0,
+            total_reveals: 0,
+            total_auction_bids: 0,
+            total_auctions_settled: 0,
+            cumulative_fee_bps_collected: 0,
         })
 }
 
-pub fn reveal_borrow(
-    env: &Env,
-    owner: Address,
-    commit_id: u64,
-) -> Result<(Option<Address>, i128, i128), MevProtectionError> {
-    owner.require_auth();
-    let commit = validate_reveal(env, &owner, commit_id, SensitiveOperation::Borrow)?;
-    let effective_fee_bps = preview_fee_bps(
-        env,
-        SensitiveOperation::Borrow,
-        commit.asset.clone(),
-        commit.amount,
-    );
-    if effective_fee_bps > commit.max_fee_bps {
-        return Err(MevProtectionError::FeeCapExceeded);
-    }
-    record_ordering_signal(
-        env,
-        owner,
-        SensitiveOperation::Borrow,
-        commit.asset.clone(),
-        commit.amount,
-        effective_fee_bps,
-    );
-    env.storage()
-        .persistent()
-        .remove(&MevDataKey::Commit(commit_id));
-    Ok((commit.asset, commit.amount, effective_fee_bps))
-}
+// ─── Internal Helpers ─────────────────────────────────────────────────────────
 
-pub fn reveal_withdraw(
-    env: &Env,
-    owner: Address,
-    commit_id: u64,
-) -> Result<(Option<Address>, i128), MevProtectionError> {
-    owner.require_auth();
-    let commit = validate_reveal(env, &owner, commit_id, SensitiveOperation::Withdraw)?;
-    let effective_fee_bps = preview_fee_bps(
-        env,
-        SensitiveOperation::Withdraw,
-        commit.asset.clone(),
-        commit.amount,
-    );
-    if effective_fee_bps > commit.max_fee_bps {
-        return Err(MevProtectionError::FeeCapExceeded);
-    }
-    record_ordering_signal(
-        env,
-        owner,
-        SensitiveOperation::Withdraw,
-        commit.asset.clone(),
-        commit.amount,
-        effective_fee_bps,
-    );
-    env.storage()
-        .persistent()
-        .remove(&MevDataKey::Commit(commit_id));
-    Ok((commit.asset, commit.amount))
-}
-
-pub fn reveal_liquidation(
-    env: &Env,
-    owner: Address,
-    commit_id: u64,
-) -> Result<(Address, Option<Address>, Option<Address>, i128), MevProtectionError> {
-    owner.require_auth();
-    let commit = validate_reveal(env, &owner, commit_id, SensitiveOperation::Liquidate)?;
-    let effective_fee_bps = preview_fee_bps(
-        env,
-        SensitiveOperation::Liquidate,
-        commit.asset.clone(),
-        commit.amount,
-    );
-    if effective_fee_bps > commit.max_fee_bps {
-        return Err(MevProtectionError::FeeCapExceeded);
-    }
-    let borrower = commit
-        .borrower
-        .ok_or(MevProtectionError::InvalidOperation)?;
-    record_ordering_signal(
-        env,
-        owner,
-        SensitiveOperation::Liquidate,
-        commit.asset.clone(),
-        commit.amount,
-        effective_fee_bps,
-    );
-    env.storage()
-        .persistent()
-        .remove(&MevDataKey::Commit(commit_id));
-    Ok((
-        borrower,
-        commit.asset,
-        commit.secondary_asset,
-        commit.amount,
-    ))
-}
-
-fn validate_reveal(
-    env: &Env,
-    owner: &Address,
-    commit_id: u64,
-    expected: SensitiveOperation,
-) -> Result<PendingCommit, MevProtectionError> {
-    let commit = load_commit(env, commit_id)?;
-    if commit.owner != *owner {
-        return Err(MevProtectionError::Unauthorized);
-    }
-    if commit.operation != expected {
-        return Err(MevProtectionError::InvalidOperation);
-    }
-    let now = env.ledger().timestamp();
-    if now < commit.reveal_after {
-        return Err(MevProtectionError::CommitNotReady);
-    }
-    if now > commit.expires_at {
-        return Err(MevProtectionError::CommitExpired);
-    }
-    Ok(commit)
-}
-
+/// Record an ordering observation and update sandwich / suspicious-sequence counters.
 fn record_ordering_signal(
     env: &Env,
     actor: Address,
@@ -416,13 +937,18 @@ fn record_ordering_signal(
     let previous: Option<OrderingObservation> = env.storage().persistent().get(&previous_key);
     let mut stats = get_ordering_stats(env);
 
-    if let Some(last) = latest.clone() {
-        if now.saturating_sub(last.timestamp) <= cfg.suspicious_window_secs && last.actor != actor {
+    // Detect suspicious ordering: two different actors within the window
+    if let Some(ref last) = latest {
+        if now.saturating_sub(last.timestamp) <= cfg.suspicious_window_secs
+            && last.actor != actor
+        {
             stats.suspicious_sequences = stats.suspicious_sequences.saturating_add(1);
         }
     }
 
-    if let (Some(prev), Some(last)) = (previous.clone(), latest.clone()) {
+    // Detect sandwich: prev.actor == current.actor, last.actor != current.actor,
+    // and amounts are close (front-run / back-run pattern).
+    if let (Some(ref prev), Some(ref last)) = (&previous, &latest) {
         let prev_recent = now.saturating_sub(prev.timestamp) <= cfg.suspicious_window_secs;
         let last_recent = now.saturating_sub(last.timestamp) <= cfg.suspicious_window_secs;
         if prev_recent
@@ -440,6 +966,8 @@ fn record_ordering_signal(
     env.storage()
         .persistent()
         .set(&MevDataKey::OrderingStats, &stats);
+
+    // Rotate observations: latest → previous, new → latest
     if let Some(last) = latest {
         env.storage().persistent().set(&previous_key, &last);
     }
@@ -479,16 +1007,20 @@ fn validate_config(config: &MevProtectionConfig) -> Result<(), MevProtectionErro
     if config.commit_delay_secs == 0
         || config.commit_expiry_secs <= config.commit_delay_secs
         || config.suspicious_window_secs == 0
+        || config.batch_window_secs == 0
         || !(0..=MAX_BPS).contains(&config.fee_smoothing_bps)
         || !(0..=MAX_BPS).contains(&config.base_protection_fee_bps)
         || !(0..=MAX_BPS).contains(&config.surge_protection_fee_bps)
         || !(0..=MAX_BPS).contains(&config.sandwich_threshold_bps)
+        || !(0..=MAX_BPS).contains(&config.default_max_slippage_bps)
     {
         return Err(MevProtectionError::InvalidConfig);
     }
     Ok(())
 }
 
+/// Returns true when the absolute difference between `a` and `b` is within
+/// `threshold_bps` of the larger value.
 fn amounts_close(a: i128, b: i128, threshold_bps: i128) -> bool {
     if a == 0 && b == 0 {
         return true;


### PR DESCRIPTION











closes #383 

feat: implement MEV protection mechanisms

- Batch auction for liquidation opportunities with uniform clearing fee
- Commit-reveal scheme with slippage protection and deadline parameters
- Private mempool integration with Flashbots-style routing hints
- Gas price bidding analysis (smoothed fee, surge detection, recommendations)
- MEV extraction monitoring dashboard with sandwich/ordering detection
- Extended OrderingStats with full lifecycle counters
- New API: POST /mev/commit, /mev/reveal, /mev/auction/bid, /mev/auction/settle
- New API: GET /mev/dashboard, /mev/gas-analysis, /mev/route, /mev/fee-preview
- Wired mevRoutes into app.ts at /api/mev
- Mapped new MevProtectionError variants in errors.rs


















