### PR TITLE
feat(oracle): add Oracle provider failover with priority ordering

### DIFF
--- a/oracle/src/services/price-aggregator.ts
+++ b/oracle/src/services/price-aggregator.ts
@@ -21,6 +21,23 @@ import { logger } from '../utils/logger.js';
 export interface AggregatorConfig {
   minSources: number;
   useWeightedMedian: boolean;
+  /**
+   * Enable priority-based failover mode.
+   *
+   * When true, providers are tried in ascending priority order (1 = highest).
+   * The aggregator stops as soon as it collects a valid price from the
+   * highest-priority available provider and does NOT query lower-priority
+   * providers — keeping latency minimal when the primary is healthy.
+   *
+   * Lower-priority providers are only consulted when all higher-priority
+   * providers fail or have open circuit breakers.  When a previously-failed
+   * provider recovers (circuit breaker closes), it is automatically preferred
+   * again on the next request.
+   *
+   * When false (default), all enabled providers are queried and their results
+   * are aggregated via weighted median.
+   */
+  failoverMode?: boolean;
   circuitBreaker?: Partial<Omit<CircuitBreakerConfig, 'providerName'>>;
 }
 
@@ -30,6 +47,7 @@ export interface AggregatorConfig {
 const DEFAULT_CONFIG: AggregatorConfig = {
   minSources: 1,
   useWeightedMedian: true,
+  failoverMode: false,
 };
 
 /**
@@ -131,9 +149,86 @@ export class PriceAggregator {
   }
 
   /**
-   * Fetch price from providers with fallback logic
+   * Fetch price from providers with fallback logic.
+   *
+   * In **failover mode** providers are tried in priority order (lowest number
+   * first).  As soon as a valid price is obtained from the highest-available
+   * provider the method returns immediately — lower-priority providers are
+   * never queried, keeping latency minimal when the primary is healthy.
+   * If the current provider fails its circuit breaker opens and the next
+   * lower-priority provider is tried automatically.  When the failed provider
+   * recovers (circuit breaker transitions back to CLOSED) it will be preferred
+   * again on the next call.
+   *
+   * In **aggregation mode** (default) all enabled providers are queried and
+   * their results are combined via weighted median.
    */
   private async fetchWithFallback(asset: string): Promise<PriceData[]> {
+    return this.config.failoverMode
+      ? this.fetchWithPriorityFailover(asset)
+      : this.fetchFromAllProviders(asset);
+  }
+
+  /**
+   * Priority-based failover: try providers in priority order and return as
+   * soon as the highest-available provider succeeds.  Lower-priority providers
+   * are only consulted when all higher-priority ones are unavailable or fail.
+   *
+   * Recovery is automatic: once a higher-priority provider's circuit breaker
+   * closes it will be tried first again on the next request.
+   */
+  private async fetchWithPriorityFailover(asset: string): Promise<PriceData[]> {
+    // Providers are already sorted by ascending priority (1 = highest)
+    for (const provider of this.providers) {
+      const circuitBreaker = this.circuitBreakers.get(provider.name);
+
+      if (circuitBreaker && !circuitBreaker.isAllowed()) {
+        logger.warn(
+          `[failover] Circuit breaker OPEN for ${provider.name} (priority ${provider.priority}), trying next provider`
+        );
+        continue;
+      }
+
+      try {
+        const rawPrice = await provider.fetchPrice(asset);
+        const validation = this.validator.validate(rawPrice);
+
+        if (validation.isValid && validation.price) {
+          circuitBreaker?.recordSuccess();
+
+          logger.debug(
+            `[failover] Got valid price from ${provider.name} (priority ${provider.priority}) for ${asset}`,
+            { price: validation.price.price.toString() }
+          );
+
+          // Return immediately — do not query lower-priority providers
+          return [validation.price];
+        }
+
+        // Invalid price counts as a failure
+        circuitBreaker?.recordFailure();
+        logger.warn(
+          `[failover] Invalid price from ${provider.name} (priority ${provider.priority}) for ${asset}, trying next provider`,
+          { errors: validation.errors }
+        );
+      } catch (error) {
+        circuitBreaker?.recordFailure();
+        logger.warn(
+          `[failover] Provider ${provider.name} (priority ${provider.priority}) failed for ${asset}, trying next provider`,
+          { error }
+        );
+      }
+    }
+
+    logger.error(`[failover] All providers failed for ${asset}`);
+    return [];
+  }
+
+  /**
+   * Aggregation mode: query all providers and collect every valid price for
+   * weighted-median aggregation.
+   */
+  private async fetchFromAllProviders(asset: string): Promise<PriceData[]> {
     const validPrices: PriceData[] = [];
     const errors: Map<string, Error> = new Map();
 
@@ -303,11 +398,19 @@ export class PriceAggregator {
   }
 
   /**
+   * Returns true when the aggregator is running in priority-based failover mode.
+   */
+  isFailoverMode(): boolean {
+    return this.config.failoverMode ?? false;
+  }
+
+  /**
    * Get aggregator statistics
    */
   getStats() {
     return {
       enabledProviders: this.providers.length,
+      failoverMode: this.isFailoverMode(),
       cacheStats: this.cache.getStats(),
       priceHistoryStats: this.priceHistory.getStats(),
       circuitBreakerMetrics: this.getCircuitBreakerMetrics(),
@@ -321,7 +424,12 @@ function isAggregatorConfig(value: unknown): value is Partial<AggregatorConfig> 
     return false;
   }
 
-  return 'minSources' in value || 'useWeightedMedian' in value || 'circuitBreaker' in value;
+  return (
+    'minSources' in value ||
+    'useWeightedMedian' in value ||
+    'failoverMode' in value ||
+    'circuitBreaker' in value
+  );
 }
 
 function isPriceHistoryService(value: unknown): value is PriceHistoryService {

--- a/oracle/tests/price-aggregator.test.ts
+++ b/oracle/tests/price-aggregator.test.ts
@@ -188,3 +188,152 @@ describe('PriceAggregator', () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// Priority-based failover tests
+// ---------------------------------------------------------------------------
+
+describe('PriceAggregator – priority-based failover', () => {
+  let high: MockProvider; // priority 1 (highest)
+  let mid: MockProvider;  // priority 2
+  let low: MockProvider;  // priority 3 (lowest)
+
+  function makeFailoverAggregator(failureThreshold = 1) {
+    const validator = createValidator({ maxDeviationPercent: 50, maxStalenessSeconds: 300 });
+    const cache = createPriceCache(30);
+    return createAggregator([high, mid, low], validator, cache, {
+      minSources: 1,
+      failoverMode: true,
+      circuitBreaker: { failureThreshold, backoffMs: 60_000 },
+    });
+  }
+
+  beforeEach(() => {
+    high = new MockProvider('high', 1, 0.5, { XLM: 0.15 });
+    mid  = new MockProvider('mid',  2, 0.3, { XLM: 0.152 });
+    low  = new MockProvider('low',  3, 0.2, { XLM: 0.148 });
+  });
+
+  it('uses highest-priority provider when healthy', async () => {
+    const agg = makeFailoverAggregator();
+    const result = await agg.getPrice('XLM');
+
+    expect(result).not.toBeNull();
+    expect(result!.sources).toHaveLength(1);
+    expect(result!.sources[0].source).toBe('high');
+  });
+
+  it('does NOT query lower-priority providers when primary succeeds', async () => {
+    const midSpy = vi.spyOn(mid, 'fetchPrice');
+    const lowSpy = vi.spyOn(low, 'fetchPrice');
+
+    const agg = makeFailoverAggregator();
+    await agg.getPrice('XLM');
+
+    expect(midSpy).not.toHaveBeenCalled();
+    expect(lowSpy).not.toHaveBeenCalled();
+  });
+
+  it('fails over to mid-priority provider when high-priority fails', async () => {
+    high.setFail(true);
+    const agg = makeFailoverAggregator();
+    const result = await agg.getPrice('XLM');
+
+    expect(result).not.toBeNull();
+    expect(result!.sources[0].source).toBe('mid');
+  });
+
+  it('fails over to lowest-priority provider when high and mid both fail', async () => {
+    high.setFail(true);
+    mid.setFail(true);
+    const agg = makeFailoverAggregator();
+    const result = await agg.getPrice('XLM');
+
+    expect(result).not.toBeNull();
+    expect(result!.sources[0].source).toBe('low');
+  });
+
+  it('returns null when all providers fail', async () => {
+    high.setFail(true);
+    mid.setFail(true);
+    low.setFail(true);
+    const agg = makeFailoverAggregator();
+    const result = await agg.getPrice('XLM');
+
+    expect(result).toBeNull();
+  });
+
+  it('skips provider with open circuit breaker and uses next in priority order', async () => {
+    // failureThreshold=1 → one failure opens the circuit
+    const agg = makeFailoverAggregator(1);
+
+    // Open high's circuit breaker
+    high.setFail(true);
+    await agg.getPrice('XLM'); // mid serves; high's CB opens
+
+    // Verify high's circuit breaker is now OPEN
+    const metrics = agg.getCircuitBreakerMetrics();
+    const highMetrics = metrics.find((m) => m.providerName === 'high');
+    expect(highMetrics?.state).toBe('OPEN');
+  });
+
+  it('recovers to higher-priority provider after circuit breaker closes', async () => {
+    const validator = createValidator({ maxDeviationPercent: 50, maxStalenessSeconds: 300 });
+
+    // backoffMs=0 → circuit moves to HALF_OPEN immediately after failure
+    const cache = createPriceCache(30);
+    const agg = createAggregator([high, mid, low], validator, cache, {
+      minSources: 1,
+      failoverMode: true,
+      circuitBreaker: { failureThreshold: 1, backoffMs: 0 },
+    });
+
+    // 1. High fails → circuit opens → mid serves
+    high.setFail(true);
+    const r1 = await agg.getPrice('XLM');
+    expect(r1!.sources[0].source).toBe('mid');
+
+    // 2. High recovers; backoffMs=0 → HALF_OPEN probe allowed immediately
+    high.setFail(false);
+
+    // Use a fresh cache so the next getPrice() triggers a real fetch
+    const cache2 = createPriceCache(30);
+    const agg2 = createAggregator([high, mid, low], validator, cache2, {
+      minSources: 1,
+      failoverMode: true,
+      circuitBreaker: { failureThreshold: 1, backoffMs: 0 },
+    });
+
+    // Open circuit for high in agg2
+    high.setFail(true);
+    await agg2.getPrice('XLM'); // opens circuit
+    high.setFail(false);
+
+    // Next request: backoffMs=0 → HALF_OPEN probe → high succeeds → CLOSED → high serves
+    const r2 = await agg2.getPrice('XLM');
+    expect(r2!.sources[0].source).toBe('high');
+  });
+
+  it('isFailoverMode() returns true when failoverMode is enabled', () => {
+    const agg = makeFailoverAggregator();
+    expect(agg.isFailoverMode()).toBe(true);
+  });
+
+  it('isFailoverMode() returns false by default', () => {
+    const validator = createValidator({ maxDeviationPercent: 50, maxStalenessSeconds: 300 });
+    const cache = createPriceCache(30);
+    const agg = createAggregator([high, mid, low], validator, cache, { minSources: 1 });
+    expect(agg.isFailoverMode()).toBe(false);
+  });
+
+  it('getStats() includes failoverMode flag', () => {
+    const agg = makeFailoverAggregator();
+    expect(agg.getStats().failoverMode).toBe(true);
+  });
+
+  it('providers are ordered by priority (ascending)', () => {
+    const agg = makeFailoverAggregator();
+    const names = agg.getProviders();
+    expect(names).toEqual(['high', 'mid', 'low']);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #79

Implements priority-based failover for the Oracle price aggregator as described in issue #79.

## Changes

### `oracle/src/services/price-aggregator.ts`
- Added `failoverMode` option to `AggregatorConfig` (default: `false`, fully backward-compatible)
- Added `fetchWithPriorityFailover()` — tries providers in ascending priority order (1 = highest); returns immediately on first success, so **no latency increase when the primary is healthy**
- Renamed existing fetch path to `fetchFromAllProviders()` (aggregation mode, unchanged behaviour)
- Exposed `isFailoverMode()` method
- `getStats()` now includes `failoverMode` flag
- Updated `isAggregatorConfig()` type guard to recognise `failoverMode`

### `oracle/tests/price-aggregator.test.ts`
- Highest-priority provider used when healthy
- Lower-priority providers **not** queried when primary succeeds
- Automatic failover to mid / low priority on failure
- `null` returned when all providers fail
- Open circuit breaker skipped; next provider used
- Recovery: higher-priority provider preferred again after circuit breaker closes
- `isFailoverMode()` and `getStats().failoverMode` assertions
- Providers ordered by ascending priority

## Acceptance Criteria

| Criterion | Status |
|---|---|
| Providers ordered by priority | ✅ |
| Higher-priority provider preferred when available | ✅ |
| Automatic failover to lower priority on failure | ✅ |
| Recovery: switch back to higher priority when it recovers | ✅ |
| Tests for failover and recovery | ✅ |
| No latency increase when primary provider is healthy | ✅ |