### PR TITLE
feat: batch liquidation, field selection, Redis caching, and Rust building caching

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -29,13 +29,20 @@ jobs:
           toolchain: stable
           components: rustfmt, clippy
 
+      - name: Install sccache
+        uses: mozilla-actions/sccache-action@v0.0.4
+
+      - name: Configure sccache
+        run: |
+          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+
       - name: Cache cargo registry & build
         uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            stellar-lend/target
           key: ${{ runner.os }}-cargo-${{ hashFiles('stellar-lend/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
@@ -107,10 +114,18 @@ jobs:
           name: differential-test-report
           path: stellar-lend/differential-test-report.txt
 
+      - name: Cache cargo-audit binary
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/cargo-audit
+          key: ${{ runner.os }}-cargo-audit-${{ hashFiles('stellar-lend/.cargo/audit.toml') }}
+
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+
       - name: Run security audit
         run: |
           cd stellar-lend
-          cargo install cargo-audit --locked
           cargo audit
 
   fuzzing:
@@ -142,6 +157,14 @@ jobs:
           key: ${{ runner.os }}-cargo-fuzz-${{ hashFiles('stellar-lend/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-fuzz-
+
+      - name: Cache cargo-fuzz binary
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/cargo-fuzz
+          key: ${{ runner.os }}-cargo-fuzz-nightly-${{ hashFiles('stellar-lend/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-fuzz-nightly-
 
       - name: Install cargo-fuzz
         run: cargo +nightly install cargo-fuzz --locked
@@ -185,6 +208,14 @@ jobs:
           key: ${{ runner.os }}-cargo-invariant-${{ hashFiles('stellar-lend/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-invariant-
+
+      - name: Cache cargo-fuzz binary
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/cargo-fuzz
+          key: ${{ runner.os }}-cargo-fuzz-nightly-${{ hashFiles('stellar-lend/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-fuzz-nightly-
 
       - name: Install cargo-fuzz
         run: cargo +nightly install cargo-fuzz --locked

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -27,6 +27,7 @@ import logger from './utils/logger';
 import { requestIdMiddleware } from './middleware/requestId';
 import { requestLogger } from './middleware/requestLogger';
 import { sanitizeInput } from './middleware/sanitizeInput';
+import { fieldSelectionMiddleware } from './middleware/fieldSelection';
 import { redisCacheService } from './services/redisCache.service';
 
 const app: Application = express();
@@ -82,6 +83,7 @@ app.use(express.json({ limit: config.bodySizeLimit.limit }));
 app.use(express.urlencoded({ extended: true, limit: config.bodySizeLimit.limit }));
 app.use(sanitizeInput);
 app.use(bodySizeLimitMiddleware);
+app.use(fieldSelectionMiddleware);
 
 const limiter = rateLimit({
   windowMs: config.rateLimit.windowMs,
@@ -148,7 +150,11 @@ app.use('/api/mev', mevRoutes);
 
 app.use(errorHandler);
 
-void redisCacheService.warmup();
+void redisCacheService.warmup(async () => {
+  const { StellarService } = await import('./services/stellar.service');
+  const svc = new StellarService();
+  await svc.getProtocolStats();
+});
 
 export async function resetRateLimiters(): Promise<void> {
   resetSensitiveRateLimits();

--- a/api/src/middleware/fieldSelection.ts
+++ b/api/src/middleware/fieldSelection.ts
@@ -1,0 +1,64 @@
+import { Request, Response, NextFunction } from 'express';
+
+function pickFields(
+  obj: Record<string, unknown>,
+  fields: Set<string>
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const key of fields) {
+    if (Object.prototype.hasOwnProperty.call(obj, key)) {
+      result[key] = obj[key];
+    }
+  }
+  return result;
+}
+
+function applyFieldSelection(body: unknown, fields: Set<string>): unknown {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    return body;
+  }
+  const obj = body as Record<string, unknown>;
+  // Envelope pattern: filter items inside data array, pass meta keys through
+  if (Array.isArray(obj.data)) {
+    return {
+      ...obj,
+      data: (obj.data as unknown[]).map((item) =>
+        item && typeof item === 'object' && !Array.isArray(item)
+          ? pickFields(item as Record<string, unknown>, fields)
+          : item
+      ),
+    };
+  }
+  return pickFields(obj, fields);
+}
+
+export function fieldSelectionMiddleware(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void {
+  const rawFields = req.query.fields;
+  if (!rawFields || typeof rawFields !== 'string' || rawFields.trim() === '') {
+    return next();
+  }
+
+  const fields = new Set(
+    rawFields
+      .split(',')
+      .map((f) => f.trim())
+      .filter(Boolean)
+  );
+
+  if (fields.size === 0) {
+    return next();
+  }
+
+  const originalJson = res.json.bind(res) as (body?: unknown) => Response;
+  (res as unknown as { json: (body?: unknown) => Response }).json = function (
+    body?: unknown
+  ): Response {
+    return originalJson(applyFieldSelection(body, fields));
+  };
+
+  next();
+}

--- a/api/src/routes/health.routes.ts
+++ b/api/src/routes/health.routes.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import * as lendingController from '../controllers/lending.controller';
+import { redisCacheService } from '../services/redisCache.service';
 
 const router: Router = Router();
 
@@ -114,5 +115,20 @@ router.get('/', lendingController.healthCheck);
  *                       description: Number of requests that timed out waiting for coalescing
  */
 router.get('/coalescing', lendingController.coalescingMetrics);
+
+/**
+ * @openapi
+ * /health/cache-metrics:
+ *   get:
+ *     summary: Redis cache performance metrics
+ *     tags:
+ *       - Health
+ *     responses:
+ *       200:
+ *         description: Cache hit/miss/error counters
+ */
+router.get('/cache-metrics', (_req, res) => {
+  res.json(redisCacheService.getMetrics());
+});
 
 export default router;

--- a/api/src/services/redisCache.service.ts
+++ b/api/src/services/redisCache.service.ts
@@ -32,12 +32,20 @@ class RedisCacheService {
     return `stellarlend:${kind}:${id}`;
   }
 
-  async warmup(): Promise<void> {
+  async warmup(prefetch?: () => Promise<void>): Promise<void> {
     if (!this.redis) return;
     try {
       await this.redis.connect();
       await this.redis.ping();
       logger.info('Redis cache warmed');
+      if (prefetch) {
+        try {
+          await prefetch();
+          logger.info('Redis cache pre-fetched');
+        } catch (prefetchError) {
+          logger.warn('Redis cache prefetch failed', { error: prefetchError });
+        }
+      }
     } catch (error) {
       this.metrics.errors += 1;
       logger.warn('Redis warmup failed, memory fallback remains active', { error });
@@ -86,6 +94,19 @@ class RedisCacheService {
     } catch (error) {
       this.metrics.errors += 1;
       logger.warn('Cache set failed', { key, error });
+    }
+  }
+
+  async del(key: string): Promise<void> {
+    try {
+      if (this.redis?.status === 'ready') {
+        await this.redis.del(key);
+        return;
+      }
+      this.memoryFallback.delete(key);
+    } catch (error) {
+      this.metrics.errors += 1;
+      logger.warn('Cache del failed', { key, error });
     }
   }
 

--- a/stellar-lend/.cargo/config.toml
+++ b/stellar-lend/.cargo/config.toml
@@ -1,0 +1,5 @@
+[build]
+incremental = true
+
+[net]
+retry = 2

--- a/stellar-lend/Cargo.lock
+++ b/stellar-lend/Cargo.lock
@@ -1458,6 +1458,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lending-core"
+version = "0.1.0"
+dependencies = [
+ "lending-types",
+ "soroban-sdk",
+ "test-utils",
+]
+
+[[package]]
+name = "lending-interest"
+version = "0.1.0"
+dependencies = [
+ "lending-types",
+ "soroban-sdk",
+ "test-utils",
+]
+
+[[package]]
+name = "lending-risk"
+version = "0.1.0"
+dependencies = [
+ "lending-types",
+ "soroban-sdk",
+ "test-utils",
+]
+
+[[package]]
+name = "lending-types"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2844,6 +2878,14 @@ dependencies = [
  "quote",
  "syn 2.0.117",
  "test-case-core",
+]
+
+[[package]]
+name = "test-utils"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+ "soroban-token-sdk",
 ]
 
 [[package]]

--- a/stellar-lend/Cargo.toml
+++ b/stellar-lend/Cargo.toml
@@ -20,6 +20,8 @@ members = [
 ]
 exclude = ["fuzz"]
 
+[workspace.lints.rust]
+
 [workspace.dependencies]
 soroban-sdk = "23.4.1"
 soroban-token-sdk = { version = "23.4.1" }
@@ -41,3 +43,9 @@ codegen-units = 1
 [profile.release-with-logs]
 inherits = "release"
 debug-assertions = true
+
+[profile.dev]
+incremental = true
+
+[profile.test]
+incremental = true

--- a/stellar-lend/contracts/hello-world/src/events.rs
+++ b/stellar-lend/contracts/hello-world/src/events.rs
@@ -782,3 +782,19 @@ pub struct LiquidationCancelledEvent {
     pub caller: Address,
     pub timestamp: u64,
 }
+
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct BatchLiquidationEvent {
+    pub liquidator: Address,
+    pub total_positions: u32,
+    pub successful: u32,
+    pub failed: u32,
+    pub total_debt_liquidated: i128,
+    pub total_collateral_seized: i128,
+    pub timestamp: u64,
+}
+
+pub fn emit_batch_liquidation(e: &Env, event: BatchLiquidationEvent) {
+    event.publish(e);
+}

--- a/stellar-lend/contracts/hello-world/src/lib.rs
+++ b/stellar-lend/contracts/hello-world/src/lib.rs
@@ -703,6 +703,29 @@ impl HelloContract {
         .map_err(Into::into)
     }
 
+    /// Liquidate up to `MAX_BATCH_SIZE` undercollateralized positions in one transaction.
+    ///
+    /// Amortizes authentication and submission overhead across all positions.
+    /// Per-position failures are captured in the returned results and do not abort
+    /// the entire batch.
+    pub fn batch_liquidate(
+        env: Env,
+        liquidator: Address,
+        requests: soroban_sdk::Vec<liquidate::BatchLiquidationRequest>,
+    ) -> Result<soroban_sdk::Vec<liquidate::BatchLiquidationResult>, LendingError> {
+        liquidator.require_auth();
+        let pool = env.current_contract_address();
+        rate_limiter::consume(
+            &env,
+            &liquidator,
+            &liquidator,
+            &soroban_sdk::Symbol::new(&env, "batch_liquidate"),
+            &pool,
+        )
+        .map_err(|_| LendingError::LimitExceeded)?;
+        liquidate::batch_liquidate(&env, liquidator, requests).map_err(Into::into)
+    }
+
     pub fn configure_mev_protection(
         env: Env,
         caller: Address,

--- a/stellar-lend/contracts/hello-world/src/liquidate.rs
+++ b/stellar-lend/contracts/hello-world/src/liquidate.rs
@@ -22,10 +22,10 @@
 
 #![allow(unused)]
 use crate::events::{
-    emit_liquidation, emit_liquidation_fee_collected, LiquidationEvent,
-    LiquidationFeeCollectedEvent,
+    emit_batch_liquidation, emit_liquidation, emit_liquidation_fee_collected,
+    BatchLiquidationEvent, LiquidationEvent, LiquidationFeeCollectedEvent,
 };
-use soroban_sdk::{contracterror, Address, Env, IntoVal, Map, Symbol, Val, Vec};
+use soroban_sdk::{contracttype, contracterror, Address, Env, IntoVal, Map, Symbol, Val, Vec};
 
 use crate::deposit::{
     add_activity_log, emit_analytics_updated_event, emit_position_updated_event,
@@ -43,6 +43,31 @@ use crate::risk_params::{
 
 /// Maximum liquidation penalty cap in basis points (20%)
 const MAX_PENALTY_BPS: i128 = 2_000;
+
+/// Maximum number of positions that can be liquidated in a single batch
+pub const MAX_BATCH_SIZE: u32 = 10;
+
+/// Input item for a batch liquidation call
+#[contracttype]
+#[derive(Clone)]
+pub struct BatchLiquidationRequest {
+    pub borrower: Address,
+    pub debt_asset: Option<Address>,
+    pub collateral_asset: Option<Address>,
+    pub debt_amount: i128,
+}
+
+/// Per-position result within a batch liquidation
+#[contracttype]
+#[derive(Clone)]
+pub struct BatchLiquidationResult {
+    pub borrower: Address,
+    pub success: bool,
+    pub debt_liquidated: i128,
+    pub collateral_seized: i128,
+    /// 0 on success; LiquidationError discriminant on failure
+    pub error_code: u32,
+}
 
 /// Calculate a dynamic liquidation penalty that scales with health factor severity.
 ///
@@ -750,4 +775,89 @@ fn update_liquidation_analytics(
         .set(&protocol_analytics_key, &protocol_analytics);
 
     Ok(())
+}
+
+/// Liquidate multiple undercollateralized positions in a single atomic transaction.
+///
+/// Processes up to `MAX_BATCH_SIZE` positions in one call, reducing the per-position
+/// overhead of separate transaction submissions. Per-position failures are captured in
+/// the result and do not abort the entire batch.
+///
+/// Authorization and rate-limiting are applied once in the contract entry point
+/// (`lib.rs`), not here.
+pub fn batch_liquidate(
+    env: &Env,
+    liquidator: Address,
+    requests: Vec<BatchLiquidationRequest>,
+) -> Result<Vec<BatchLiquidationResult>, LiquidationError> {
+    if requests.is_empty() {
+        return Err(LiquidationError::InvalidAmount);
+    }
+    if requests.len() as u32 > MAX_BATCH_SIZE {
+        return Err(LiquidationError::InvalidAmount);
+    }
+
+    let timestamp = env.ledger().timestamp();
+    let mut results: Vec<BatchLiquidationResult> = Vec::new(env);
+    let mut total_debt_liquidated: i128 = 0;
+    let mut total_collateral_seized: i128 = 0;
+    let mut successful: u32 = 0;
+    let mut failed: u32 = 0;
+
+    let n = requests.len();
+    for i in 0..n {
+        let req = requests.get(i).unwrap();
+        let outcome = liquidate(
+            env,
+            liquidator.clone(),
+            req.borrower.clone(),
+            req.debt_asset.clone(),
+            req.collateral_asset.clone(),
+            req.debt_amount,
+        );
+        let result = match outcome {
+            Ok((debt_liq, col_seized, _incentive)) => {
+                total_debt_liquidated = total_debt_liquidated
+                    .checked_add(debt_liq)
+                    .unwrap_or(i128::MAX);
+                total_collateral_seized = total_collateral_seized
+                    .checked_add(col_seized)
+                    .unwrap_or(i128::MAX);
+                successful += 1;
+                BatchLiquidationResult {
+                    borrower: req.borrower,
+                    success: true,
+                    debt_liquidated: debt_liq,
+                    collateral_seized: col_seized,
+                    error_code: 0,
+                }
+            }
+            Err(e) => {
+                failed += 1;
+                BatchLiquidationResult {
+                    borrower: req.borrower,
+                    success: false,
+                    debt_liquidated: 0,
+                    collateral_seized: 0,
+                    error_code: e as u32,
+                }
+            }
+        };
+        results.push_back(result);
+    }
+
+    emit_batch_liquidation(
+        env,
+        BatchLiquidationEvent {
+            liquidator,
+            total_positions: n as u32,
+            successful,
+            failed,
+            total_debt_liquidated,
+            total_collateral_seized,
+            timestamp,
+        },
+    );
+
+    Ok(results)
 }


### PR DESCRIPTION
 ## Summary

  - Implement batch liquidation to reduce per-position gas overhead (#372)
  - Add sparse field selection middleware to shrink API payloads (#373)
  - Wire Redis caching gaps: startup pre-fetch, `del()`, and metrics endpoint (#374)
  - Optimize Rust CI build times with sccache, incremental compilation, and binary caching (#375)

  ## Changes

  ### #372 — Batch Liquidation (`hello-world` contract)
  - `BatchLiquidationRequest` / `BatchLiquidationResult` contract types in `liquidate.rs`
  - `batch_liquidate()` processes up to 10 positions atomically; per-position failures captured in result struct
  rather than aborting the batch
  - `BatchLiquidationEvent` emitted once per call with aggregate totals
  - `batch_liquidate` entry point in `lib.rs` follows the same auth+rate-limit pattern as `liquidate`

  ### #373 — Field Selection (`api/src/middleware/fieldSelection.ts`)
  - New middleware intercepts `res.json()` when `?fields=id,amount,status` is present
  - Filters items in `data` array envelopes; leaves pagination meta keys untouched
  - No-op when `fields` param is absent — full responses unchanged

  ### #374 — Redis Caching (`api/src/services/redisCache.service.ts`)
  - `del(key)` single-key deletion added alongside existing `delByPrefix`
  - `warmup(prefetch?)` now accepts an optional async callback; on startup it pre-fetches protocol stats into
  Redis
  - `GET /api/health/cache-metrics` exposes `{ hits, misses, errors }` counters

  ### #375 — Rust Build Caching
  - `stellar-lend/.cargo/config.toml`: `[build] incremental = true`, `[net] retry = 2`
  - `Cargo.toml`: `[profile.dev]` and `[profile.test]` with `incremental = true`; `[workspace.lints.rust]` added
  to fix pre-existing manifest error
  - `ci-cd.yml`: `mozilla-actions/sccache-action@v0.0.4` on contracts job; `cargo-audit` binary cached by
  `audit.toml` hash; `cargo-fuzz` binary cached by `Cargo.lock` hash in both fuzzing and invariant-testing jobs

  Closes #372
  Closes #373
  Closes #374
  Closes #375