### PR TITLE
feat(#325): implement TWAP oracle with manipulation resistance

### DIFF
--- a/api/src/controllers/lending.controller.ts
+++ b/api/src/controllers/lending.controller.ts
@@ -393,6 +393,40 @@ export const verifyAuditLogIntegrity = (_req: Request, res: Response) => {
   return res.status(result.valid ? 200 : 409).json(result);
 };
 
+/**
+ * Get TWAP-based liquidation price for an asset.
+ *
+ * Uses the oracle contract's TWAP accumulator (get_liquidation_price)
+ * to provide manipulation-resistant pricing for liquidation calculations.
+ * Falls back to median spot price across sources when manipulation is detected.
+ */
+export const getLiquidationPrice = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { asset } = req.params;
+
+    if (!asset) {
+      return res.status(400).json({
+        success: false,
+        error: 'Asset address is required',
+      });
+    }
+
+    const stellarService = new StellarService();
+    const price = await stellarService.getLiquidationPrice(asset);
+
+    return res.status(200).json({
+      success: true,
+      asset,
+      liquidationPrice: price,
+      pricingMethod: 'twap_with_median_fallback',
+      description:
+        'TWAP-based price with manipulation resistance. Falls back to median across sources when manipulation is detected.',
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
 // Rebalancing Endpoints
 export const configureRebalancing = async (req: Request, res: Response, next: NextFunction) => {
   try {

--- a/api/src/routes/lending.routes.ts
+++ b/api/src/routes/lending.routes.ts
@@ -220,4 +220,25 @@ router.get(
  */
 router.get('/transactions/:userAddress/stream', lendingController.streamTransactionHistory);
 
+/**
+ * @openapi
+ * /lending/liquidation-price/{asset}:
+ *   get:
+ *     summary: Get TWAP-based liquidation price
+ *     description: Returns the manipulation-resistant TWAP liquidation price for an asset with fallback to median across sources.
+ *     tags:
+ *       - Lending
+ *     parameters:
+ *       - in: path
+ *         name: asset
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Asset contract address
+ *     responses:
+ *       200:
+ *         description: TWAP-based liquidation price
+ */
+router.get('/liquidation-price/:asset', lendingController.getLiquidationPrice);
+
 export default router;

--- a/api/src/services/stellar.service.ts
+++ b/api/src/services/stellar.service.ts
@@ -318,6 +318,25 @@ export class StellarService {
     return decodeSimulationResult(simulation);
   }
 
+  /**
+   * Get TWAP-based liquidation price for an asset.
+   * Calls the contract's get_liquidation_price function which returns TWAP
+   * with fallback to median spot price across sources on manipulation.
+   */
+  async getLiquidationPrice(asset: string): Promise<string> {
+    try {
+      const assetAddress = new Address(asset);
+      const result = await this.simulateContractCall(
+        'get_liquidation_price',
+        assetAddress.toScVal()
+      );
+      return result?.toString() ?? '0';
+    } catch (error) {
+      logger.error('Failed to get liquidation price:', error);
+      return '0';
+    }
+  }
+
   async getProtocolStats(): Promise<ProtocolStatsResponse> {
     const coalescingKey = requestCoalescingService.generateKey('getProtocolStats', {});
 

--- a/oracle/src/services/index.ts
+++ b/oracle/src/services/index.ts
@@ -32,3 +32,14 @@ export {
     createOracleIncidentMonitor,
 } from './oracle-incident-monitor.js';
 export type { OracleIncident } from './oracle-incident-monitor.js';
+
+export { TWAPService, createTWAPService } from './twap.service.js';
+export type { TWAPConfig, TWAPStatus } from './twap.service.js';
+
+export {
+    ManipulationDetector,
+    AlertSeverity,
+    AlertType,
+    createManipulationDetector,
+} from './manipulation-detector.js';
+export type { ManipulationAlert, ManipulationDetectorConfig } from './manipulation-detector.js';

--- a/oracle/src/services/manipulation-detector.ts
+++ b/oracle/src/services/manipulation-detector.ts
@@ -1,0 +1,463 @@
+/**
+ * Manipulation Detection Service
+ *
+ * Monitors oracle price feeds for signs of manipulation and triggers
+ * protective responses including alerts, circuit breaker activation,
+ * and fallback to median pricing across sources.
+ *
+ * Detection strategies:
+ * 1. Source deviation monitoring — compares individual source prices
+ *    against the aggregate median
+ * 2. TWAP vs spot deviation — flags when spot price diverges
+ *    significantly from the time-weighted average
+ * 3. Volatility spike detection — identifies rapid price movements
+ *    within short time windows
+ * 4. Source availability tracking — monitors source health for
+ *    early warning of feed manipulation attacks
+ */
+
+import { logger } from '../utils/logger.js';
+import type { PriceData } from '../types/index.js';
+import { calculateDeviationBps, deviationBpsToNumber } from '../utils/price-math.js';
+
+/**
+ * Manipulation alert severity levels
+ */
+export enum AlertSeverity {
+  INFO = 'info',
+  WARNING = 'warning',
+  CRITICAL = 'critical',
+}
+
+/**
+ * A single manipulation alert
+ */
+export interface ManipulationAlert {
+  id: string;
+  asset: string;
+  severity: AlertSeverity;
+  type: AlertType;
+  message: string;
+  deviationBps: number;
+  thresholdBps: number;
+  referencePrice: string;
+  observedPrice: string;
+  timestamp: number;
+  sources: string[];
+}
+
+/**
+ * Types of manipulation detection alerts
+ */
+export enum AlertType {
+  SOURCE_DEVIATION = 'source_deviation',
+  TWAP_SPOT_DEVIATION = 'twap_spot_deviation',
+  VOLATILITY_SPIKE = 'volatility_spike',
+  SOURCE_UNAVAILABILITY = 'source_unavailability',
+  LOW_LIQUIDITY_PERIOD = 'low_liquidity_period',
+}
+
+/**
+ * Detector configuration
+ */
+export interface ManipulationDetectorConfig {
+  /** Alert deviation threshold in bps (source vs median) */
+  sourceAlertBps: number;
+  /** Pause deviation threshold in bps (source vs median) */
+  sourcePauseBps: number;
+  /** TWAP vs spot deviation alert threshold in bps */
+  twapSpotAlertBps: number;
+  /** TWAP vs spot deviation pause threshold in bps */
+  twapSpotPauseBps: number;
+  /** Short-window volatility threshold in bps */
+  volatilityBps: number;
+  /** Short window for volatility check in seconds */
+  volatilityWindowSeconds: number;
+  /** Minimum sources required for safe pricing */
+  minSourcesForSafety: number;
+  /** Max alerts stored in memory */
+  maxAlerts: number;
+}
+
+const DEFAULT_CONFIG: ManipulationDetectorConfig = {
+  sourceAlertBps: 200, // 2%
+  sourcePauseBps: 1000, // 10%
+  twapSpotAlertBps: 500, // 5%
+  twapSpotPauseBps: 2500, // 25%
+  volatilityBps: 2000, // 20%
+  volatilityWindowSeconds: 600, // 10 minutes
+  minSourcesForSafety: 2,
+  maxAlerts: 100,
+};
+
+/**
+ * Snapshot of a source's state for deviation checking and drift detection.
+ * Tracks consecutive deviations to identify persistent manipulation from a single source.
+ */
+interface SourceState {
+  name: string;
+  lastPrice: bigint;
+  lastTimestamp: number;
+  /** Consecutive times this source has deviated from median */
+  consecutiveDeviations: number;
+  /** Whether this source is currently flagged as suspicious */
+  isSuspicious: boolean;
+}
+
+/**
+ * Manipulation Detection Service
+ */
+export class ManipulationDetector {
+  private config: ManipulationDetectorConfig;
+  private alerts: ManipulationAlert[] = [];
+  private sourceStates: Map<string, SourceState[]> = new Map();
+  private alertCounter: number = 0;
+
+  constructor(config: Partial<ManipulationDetectorConfig> = {}) {
+    this.config = { ...DEFAULT_CONFIG, ...config };
+    logger.info('Manipulation detector initialized', this.config);
+  }
+
+  /**
+   * Check source prices for deviation from the median.
+   * Returns alerts when individual sources diverge significantly.
+   * Tracks consecutive deviations to detect persistent manipulation from a single source.
+   */
+  checkSourceDeviations(
+    asset: string,
+    prices: PriceData[],
+    medianPrice: bigint
+  ): ManipulationAlert[] {
+    const alerts: ManipulationAlert[] = [];
+
+    for (const price of prices) {
+      if (price.price <= 0n || medianPrice <= 0n) continue;
+
+      const deviationBpsBig = calculateDeviationBps(medianPrice, price.price);
+      const deviationBps = deviationBpsToNumber(deviationBpsBig);
+      const sourceState = this.getOrCreateSourceState(asset, price.source);
+
+      if (deviationBps > this.config.sourcePauseBps) {
+        sourceState.consecutiveDeviations++;
+        sourceState.isSuspicious = true;
+
+        const alert = this.createAlert(
+          asset,
+          AlertSeverity.CRITICAL,
+          AlertType.SOURCE_DEVIATION,
+          `Source ${price.source} deviates ${deviationBps} bps from median (${sourceState.consecutiveDeviations} consecutive) — exceeding pause threshold`,
+          deviationBps,
+          this.config.sourcePauseBps,
+          medianPrice.toString(),
+          price.price.toString(),
+          prices.map((p) => p.source)
+        );
+        alerts.push(alert);
+        this.storeAlert(alert);
+      } else if (deviationBps > this.config.sourceAlertBps) {
+        sourceState.consecutiveDeviations++;
+
+        if (sourceState.consecutiveDeviations >= 3) {
+          sourceState.isSuspicious = true;
+        }
+
+        const alert = this.createAlert(
+          asset,
+          AlertSeverity.WARNING,
+          AlertType.SOURCE_DEVIATION,
+          `Source ${price.source} deviates ${deviationBps} bps from median (${sourceState.consecutiveDeviations} consecutive)`,
+          deviationBps,
+          this.config.sourceAlertBps,
+          medianPrice.toString(),
+          price.price.toString(),
+          prices.map((p) => p.source)
+        );
+        alerts.push(alert);
+        this.storeAlert(alert);
+      } else {
+        // Source is aligned — reset deviation counter
+        sourceState.consecutiveDeviations = 0;
+        sourceState.isSuspicious = false;
+      }
+
+      // Update source state with latest price
+      sourceState.lastPrice = price.price;
+      sourceState.lastTimestamp = Math.floor(Date.now() / 1000);
+      this.updateSourceState(asset, sourceState);
+    }
+
+    return alerts;
+  }
+
+  /**
+   * Get suspicious sources for an asset (sources flagged as consistently deviating).
+   */
+  getSuspiciousSources(asset: string): string[] {
+    const upperAsset = asset.toUpperCase();
+    const states = this.sourceStates.get(upperAsset) ?? [];
+    return states.filter((s) => s.isSuspicious).map((s) => s.name);
+  }
+
+  /**
+   * Get the consecutive deviation count for a specific source.
+   * Useful for monitoring dashboards.
+   */
+  getSourceDeviationCount(asset: string, source: string): number {
+    const state = this.getOrCreateSourceState(asset, source);
+    return state.consecutiveDeviations;
+  }
+
+  /**
+   * Check TWAP vs spot price deviation.
+   * Large deviations may indicate short-term manipulation of the spot market.
+   */
+  checkTWAPSpotDeviation(
+    asset: string,
+    twap: bigint,
+    spotPrice: bigint,
+    sources: string[]
+  ): ManipulationAlert | null {
+    if (twap <= 0n || spotPrice <= 0n) return null;
+
+    const deviationBps = deviationBpsToNumber(calculateDeviationBps(twap, spotPrice));
+
+    if (deviationBps > this.config.twapSpotPauseBps) {
+      const alert = this.createAlert(
+        asset,
+        AlertSeverity.CRITICAL,
+        AlertType.TWAP_SPOT_DEVIATION,
+        `Spot price deviates ${deviationBps} bps from TWAP — possible manipulation`,
+        deviationBps,
+        this.config.twapSpotPauseBps,
+        twap.toString(),
+        spotPrice.toString(),
+        sources
+      );
+      this.storeAlert(alert);
+      return alert;
+    }
+
+    if (deviationBps > this.config.twapSpotAlertBps) {
+      const alert = this.createAlert(
+        asset,
+        AlertSeverity.WARNING,
+        AlertType.TWAP_SPOT_DEVIATION,
+        `Spot price deviates ${deviationBps} bps from TWAP`,
+        deviationBps,
+        this.config.twapSpotAlertBps,
+        twap.toString(),
+        spotPrice.toString(),
+        sources
+      );
+      this.storeAlert(alert);
+      return alert;
+    }
+
+    return null;
+  }
+
+  /**
+   * Check for volatility spikes within a short time window.
+   */
+  checkVolatilitySpike(
+    asset: string,
+    currentPrice: bigint,
+    historicalPrices: Array<{ price: bigint; timestamp: number }>
+  ): ManipulationAlert | null {
+    if (currentPrice <= 0n) return null;
+
+    const now = Math.floor(Date.now() / 1000);
+    const windowStart = now - this.config.volatilityWindowSeconds;
+    let maxDeviationBps = 0;
+    let referencePrice = 0n;
+
+    for (const hist of historicalPrices) {
+      if (hist.timestamp < windowStart || hist.price <= 0n) continue;
+      const bps = this.calculateDeviationBps(hist.price, currentPrice);
+      if (bps > maxDeviationBps) {
+        maxDeviationBps = bps;
+        referencePrice = hist.price;
+      }
+    }
+
+    if (maxDeviationBps > this.config.volatilityBps) {
+      const alert = this.createAlert(
+        asset,
+        AlertSeverity.CRITICAL,
+        AlertType.VOLATILITY_SPIKE,
+        `Price moved ${maxDeviationBps} bps in ${this.config.volatilityWindowSeconds}s — volatility spike detected`,
+        maxDeviationBps,
+        this.config.volatilityBps,
+        referencePrice.toString(),
+        currentPrice.toString(),
+        []
+      );
+      this.storeAlert(alert);
+      return alert;
+    }
+
+    return null;
+  }
+
+  /**
+   * Check source availability. Triggers alerts when too few sources are
+   * available, which could indicate a feed manipulation attack.
+   */
+  checkSourceAvailability(asset: string, availableSources: string[]): ManipulationAlert | null {
+    if (availableSources.length < this.config.minSourcesForSafety) {
+      const alert = this.createAlert(
+        asset,
+        AlertSeverity.WARNING,
+        AlertType.SOURCE_UNAVAILABILITY,
+        `Only ${availableSources.length} sources available (minimum: ${this.config.minSourcesForSafety}) — potential manipulation risk`,
+        0,
+        0,
+        '0',
+        '0',
+        availableSources
+      );
+      this.storeAlert(alert);
+      return alert;
+    }
+    return null;
+  }
+
+  /**
+   * Determine if manipulation requires fallback to median pricing.
+   * Returns true when any critical alert has been raised.
+   */
+  shouldFallbackToMedian(asset: string): boolean {
+    const upperAsset = asset.toUpperCase();
+    const assetAlerts = this.alerts.filter(
+      (a) => a.asset === upperAsset && a.severity === AlertSeverity.CRITICAL
+    );
+    return assetAlerts.length > 0;
+  }
+
+  /**
+   * Get all stored alerts
+   */
+  getAlerts(asset?: string): ManipulationAlert[] {
+    if (asset) {
+      return this.alerts.filter((a) => a.asset === asset.toUpperCase());
+    }
+    return [...this.alerts];
+  }
+
+  /**
+   * Get recent alerts (within the last N seconds)
+   */
+  getRecentAlerts(seconds: number = 300, asset?: string): ManipulationAlert[] {
+    const now = Math.floor(Date.now() / 1000);
+    const threshold = now - seconds;
+    return this.getAlerts(asset).filter((a) => a.timestamp >= threshold);
+  }
+
+  /**
+   * Get detector configuration
+   */
+  getConfig(): ManipulationDetectorConfig {
+    return { ...this.config };
+  }
+
+  /**
+   * Update configuration at runtime
+   */
+  updateConfig(config: Partial<ManipulationDetectorConfig>): void {
+    this.config = { ...this.config, ...config };
+    logger.info('Manipulation detector config updated', this.config);
+  }
+
+  /**
+   * Clear stored alerts
+   */
+  clearAlerts(asset?: string): void {
+    if (asset) {
+      this.alerts = this.alerts.filter((a) => a.asset !== asset.toUpperCase());
+    } else {
+      this.alerts = [];
+    }
+  }
+
+  // ── Private helpers ─────────────────────────────────────────────────────
+
+  private calculateDeviationBps(reference: bigint, observed: bigint): number {
+    return deviationBpsToNumber(calculateDeviationBps(reference, observed));
+  }
+
+  private createAlert(
+    asset: string,
+    severity: AlertSeverity,
+    type: AlertType,
+    message: string,
+    deviationBps: number,
+    thresholdBps: number,
+    referencePrice: string,
+    observedPrice: string,
+    sources: string[]
+  ): ManipulationAlert {
+    this.alertCounter++;
+    return {
+      id: `alert_${this.alertCounter}_${Date.now()}`,
+      asset: asset.toUpperCase(),
+      severity,
+      type,
+      message,
+      deviationBps,
+      thresholdBps,
+      referencePrice,
+      observedPrice,
+      timestamp: Math.floor(Date.now() / 1000),
+      sources,
+    };
+  }
+
+  private storeAlert(alert: ManipulationAlert): void {
+    this.alerts.push(alert);
+    // Trim old alerts if exceeding max
+    while (this.alerts.length > this.config.maxAlerts) {
+      this.alerts.shift();
+    }
+
+    logger.warn(`[${alert.severity.toUpperCase()}] ${alert.type}: ${alert.message}`);
+  }
+
+  private getOrCreateSourceState(asset: string, source: string): SourceState {
+    const existing = this.getSourceState(asset, source);
+    if (existing) return existing;
+
+    return {
+      name: source,
+      lastPrice: 0n,
+      lastTimestamp: 0,
+      consecutiveDeviations: 0,
+      isSuspicious: false,
+    };
+  }
+
+  private getSourceState(asset: string, source: string): SourceState | undefined {
+    const states = this.sourceStates.get(asset.toUpperCase());
+    return states?.find((s) => s.name === source);
+  }
+
+  private updateSourceState(asset: string, state: SourceState): void {
+    const upperAsset = asset.toUpperCase();
+    const states = this.sourceStates.get(upperAsset) ?? [];
+    const idx = states.findIndex((s) => s.name === state.name);
+    if (idx >= 0) {
+      states[idx] = state;
+    } else {
+      states.push(state);
+    }
+    this.sourceStates.set(upperAsset, states);
+  }
+}
+
+/**
+ * Create a manipulation detector instance
+ */
+export function createManipulationDetector(
+  config?: Partial<ManipulationDetectorConfig>
+): ManipulationDetector {
+  return new ManipulationDetector(config);
+}

--- a/oracle/src/services/twap.service.ts
+++ b/oracle/src/services/twap.service.ts
@@ -1,0 +1,300 @@
+/**
+ * TWAP (Time-Weighted Average Price) Service
+ *
+ * Accumulates prices over time and computes TWAP values resistant to
+ * short-term manipulation. Integrates with the PriceHistoryService for
+ * observation storage and the ManipulationDetector for deviation alerts.
+ *
+ * Key features:
+ * - Configurable TWAP window (default 30 minutes)
+ * - Gas-efficient single-update-per-period accumulation
+ * - Manipulation resistance via deviation checks
+ * - Fallback to median across sources on detected manipulation
+ * - Liquidation pricing endpoint for lending protocol integration
+ */
+
+import type { AggregatedPrice } from '../types/index.js';
+import { PriceHistoryService, type TWAPResult } from './price-history.js';
+import { logger } from '../utils/logger.js';
+import { calculateDeviationBps, deviationBpsToNumber } from '../utils/price-math.js';
+
+/**
+ * TWAP service configuration
+ */
+export interface TWAPConfig {
+  /** TWAP time window in seconds (default: 1800 = 30 minutes) */
+  windowSeconds: number;
+  /** Maximum allowed deviation between TWAP and spot price (in basis points) */
+  maxDeviationBps: number;
+  /** Minimum number of data points required for valid TWAP */
+  minDataPoints: number;
+  /** Whether to fall back to median on manipulation detection */
+  fallbackToMedian: boolean;
+  /** Maximum staleness of TWAP before recomputation (seconds) */
+  maxStalenessSeconds: number;
+  /** Whether to use single-update-per-period for gas efficiency */
+  singleUpdatePerPeriod: boolean;
+}
+
+/**
+ * Default TWAP configuration
+ */
+const DEFAULT_TWAP_CONFIG: TWAPConfig = {
+  windowSeconds: 1800, // 30 minutes
+  maxDeviationBps: 500, // 5%
+  minDataPoints: 3,
+  fallbackToMedian: true,
+  maxStalenessSeconds: 60,
+  singleUpdatePerPeriod: true,
+};
+
+/**
+ * TWAP computation status
+ */
+export interface TWAPStatus {
+  twap: bigint;
+  spotPrice: bigint;
+  deviationBps: number;
+  manipulationDetected: boolean;
+  usedFallback: boolean;
+  dataPoints: number;
+  windowSeconds: number;
+  lastComputedAt: number;
+}
+
+/**
+ * Cached TWAP entry to avoid recomputation within the same period
+ */
+interface CachedTWAP {
+  twap: bigint;
+  computedAt: number;
+  spotAnchor: bigint;
+}
+
+/**
+ * TWAP Oracle Service
+ */
+export class TWAPService {
+  private priceHistory: PriceHistoryService;
+  private config: TWAPConfig;
+  private twapCache: Map<string, CachedTWAP> = new Map();
+  private lastPeriodUpdate: Map<string, number> = new Map();
+
+  constructor(priceHistory: PriceHistoryService, config: Partial<TWAPConfig> = {}) {
+    this.priceHistory = priceHistory;
+    this.config = { ...DEFAULT_TWAP_CONFIG, ...config };
+
+    logger.info('TWAP service initialized', {
+      windowSeconds: this.config.windowSeconds,
+      maxDeviationBps: this.config.maxDeviationBps,
+      fallbackToMedian: this.config.fallbackToMedian,
+      singleUpdatePerPeriod: this.config.singleUpdatePerPeriod,
+    });
+  }
+
+  /**
+   * Compute TWAP for an asset using accumulated price observations.
+   *
+   * Implements gas-efficient single-update-per-period: if a TWAP was
+   * already computed within the staleness window, returns the cached value.
+   */
+  computeTWAP(asset: string, spotPrice: bigint, now: number = Math.floor(Date.now() / 1000)): TWAPStatus | null {
+    const upperAsset = asset.toUpperCase();
+
+    // Check cache for recent computation (gas-efficient path)
+    const cached = this.twapCache.get(upperAsset);
+    if (cached && this.config.singleUpdatePerPeriod) {
+      const age = now - cached.computedAt;
+      if (age < this.config.maxStalenessSeconds) {
+        const deviationBps = this.calculateDeviationBps(cached.spotAnchor, spotPrice);
+
+        return {
+          twap: cached.twap,
+          spotPrice,
+          deviationBps,
+          manipulationDetected: deviationBps > this.config.maxDeviationBps,
+          usedFallback: false,
+          dataPoints: this.priceHistory.getPriceHistory(upperAsset).length,
+          windowSeconds: this.config.windowSeconds,
+          lastComputedAt: cached.computedAt,
+        };
+      }
+    }
+
+    // Compute fresh TWAP from price history
+    const twapResult = this.priceHistory.calculateTWAP(upperAsset, this.config.windowSeconds);
+
+    if (!twapResult || twapResult.dataPoints < this.config.minDataPoints) {
+      logger.warn(`Insufficient data for TWAP for ${upperAsset}`, {
+        dataPoints: twapResult?.dataPoints ?? 0,
+        required: this.config.minDataPoints,
+      });
+
+      // Fall back to spot price when insufficient history
+      return {
+        twap: spotPrice,
+        spotPrice,
+        deviationBps: 0,
+        manipulationDetected: false,
+        usedFallback: true,
+        dataPoints: twapResult?.dataPoints ?? 0,
+        windowSeconds: this.config.windowSeconds,
+        lastComputedAt: now,
+      };
+    }
+
+    const twap = twapResult.twap;
+    const deviationBps = this.calculateDeviationBps(twap, spotPrice);
+    const manipulationDetected = deviationBps > this.config.maxDeviationBps;
+
+    let finalTWAP = twap;
+    let usedFallback = false;
+
+    if (manipulationDetected && this.config.fallbackToMedian) {
+      logger.warn(`Manipulation detected for ${upperAsset}`, {
+        twap: twap.toString(),
+        spotPrice: spotPrice.toString(),
+        deviationBps,
+        maxDeviationBps: this.config.maxDeviationBps,
+        action: 'Falling back to spot price (median across sources)',
+      });
+
+      // Fall back to the spot price which is already a median across sources
+      finalTWAP = spotPrice;
+      usedFallback = true;
+    }
+
+    // Cache the result
+    this.twapCache.set(upperAsset, {
+      twap: finalTWAP,
+      computedAt: now,
+      spotAnchor: spotPrice,
+    });
+
+    return {
+      twap: finalTWAP,
+      spotPrice,
+      deviationBps,
+      manipulationDetected,
+      usedFallback,
+      dataPoints: twapResult.dataPoints,
+      windowSeconds: this.config.windowSeconds,
+      lastComputedAt: now,
+    };
+  }
+
+  /**
+   * Record a new price observation for TWAP accumulation.
+   * Called after each successful price fetch.
+   *
+   * In single-update-per-period mode, observations are recorded at most
+   * once per period to save gas on-chain.
+   */
+  recordObservation(asset: string, price: bigint, now: number = Math.floor(Date.now() / 1000)): void {
+    const upperAsset = asset.toUpperCase();
+
+    if (this.config.singleUpdatePerPeriod) {
+      const lastUpdate = this.lastPeriodUpdate.get(upperAsset) ?? 0;
+      const periodSeconds = Math.max(60, this.config.windowSeconds / 30); // At most one update per period/30
+
+      if (now - lastUpdate < periodSeconds) {
+        return; // Skip this observation — already updated within this period
+      }
+    }
+
+    this.priceHistory.addPriceEntry(upperAsset, price, now);
+    this.lastPeriodUpdate.set(upperAsset, now);
+  }
+
+  /**
+   * Get the TWAP-based liquidation price for an asset.
+   *
+   * This is the primary integration point for the lending protocol.
+   * Uses TWAP when sufficient history exists; falls back to median
+   * spot price across sources when manipulation is detected.
+   */
+  getLiquidationPrice(
+    asset: string,
+    spotPrice: bigint,
+    now: number = Math.floor(Date.now() / 1000)
+  ): bigint {
+    const status = this.computeTWAP(asset, spotPrice, now);
+
+    if (!status) {
+      logger.warn(`Failed to compute TWAP for ${asset}, using spot price for liquidation`);
+      return spotPrice;
+    }
+
+    if (status.manipulationDetected) {
+      logger.warn(
+        `TWAP manipulation detected for ${asset} (deviation: ${status.deviationBps} bps), ` +
+        `using fallback price for liquidation`
+      );
+    }
+
+    return status.twap;
+  }
+
+  /**
+   * Get full TWAP status including manipulation detection info
+   */
+  getTWAPStatus(asset: string, spotPrice: bigint): TWAPStatus | null {
+    return this.computeTWAP(asset, spotPrice);
+  }
+
+  /**
+   * Force recompute TWAP (bypasses cache)
+   */
+  forceRecomputeTWAP(asset: string, spotPrice: bigint): TWAPStatus | null {
+    this.twapCache.delete(asset.toUpperCase());
+    return this.computeTWAP(asset, spotPrice);
+  }
+
+  /**
+   * Get the current configuration
+   */
+  getConfig(): TWAPConfig {
+    return { ...this.config };
+  }
+
+  /**
+   * Update TWAP configuration at runtime
+   */
+  updateConfig(config: Partial<TWAPConfig>): void {
+    this.config = { ...this.config, ...config };
+    this.twapCache.clear(); // Invalidate cache on config change
+    logger.info('TWAP configuration updated', this.config);
+  }
+
+  /**
+   * Calculate deviation between two prices in basis points.
+   * Uses shared price-math utility for precision-safe calculation.
+   */
+  private calculateDeviationBps(reference: bigint, observed: bigint): number {
+    return deviationBpsToNumber(calculateDeviationBps(reference, observed));
+  }
+
+  /**
+   * Clear all cached data
+   */
+  clearCache(asset?: string): void {
+    if (asset) {
+      const upperAsset = asset.toUpperCase();
+      this.twapCache.delete(upperAsset);
+      this.lastPeriodUpdate.delete(upperAsset);
+    } else {
+      this.twapCache.clear();
+      this.lastPeriodUpdate.clear();
+    }
+  }
+}
+
+/**
+ * Create a TWAP service instance
+ */
+export function createTWAPService(
+  priceHistory: PriceHistoryService,
+  config?: Partial<TWAPConfig>
+): TWAPService {
+  return new TWAPService(priceHistory, config);
+}

--- a/oracle/src/utils/price-math.ts
+++ b/oracle/src/utils/price-math.ts
@@ -1,0 +1,66 @@
+/**
+ * Shared Price Math Utilities
+ *
+ * Common mathematical operations used across oracle services:
+ * - Price deviation calculation (basis points)
+ * - Median computation
+ * - Price normalization
+ */
+
+/**
+ * Calculate price deviation in basis points between a reference price
+ * and an observed price.
+ *
+ * Formula: |observed - reference| / reference * 10000
+ *
+ * Returns the deviation as a bigint to preserve precision for large values.
+ * For display, convert to Number only at the boundary.
+ *
+ * @param reference The reference/baseline price (must be > 0)
+ * @param observed The observed/comparison price (must be > 0)
+ * @returns Deviation in basis points, or 0n if either price is non-positive
+ */
+export function calculateDeviationBps(reference: bigint, observed: bigint): bigint {
+  if (reference <= 0n || observed <= 0n) {
+    return 0n;
+  }
+
+  const diff = observed > reference ? observed - reference : reference - observed;
+  return (diff * 10000n) / reference;
+}
+
+/**
+ * Convert bigint deviation bps to a safe Number for display/metrics.
+ * Caps at Number.MAX_SAFE_INTEGER to avoid precision loss.
+ */
+export function deviationBpsToNumber(bps: bigint): number {
+  if (bps > BigInt(Number.MAX_SAFE_INTEGER)) {
+    return Number.MAX_SAFE_INTEGER;
+  }
+  return Number(bps);
+}
+
+/**
+ * Calculate median of a sorted array of bigint values.
+ */
+export function medianBigInt(values: bigint[]): bigint | null {
+  if (values.length === 0) return null;
+
+  const sorted = [...values].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+  const mid = Math.floor(sorted.length / 2);
+
+  if (sorted.length % 2 === 0) {
+    return (sorted[mid - 1] + sorted[mid]) / 2n;
+  }
+
+  return sorted[mid];
+}
+
+/**
+ * Calculate mean (average) of bigint values.
+ */
+export function meanBigInt(values: bigint[]): bigint | null {
+  if (values.length === 0) return null;
+  const sum = values.reduce((acc, v) => acc + v, 0n);
+  return sum / BigInt(values.length);
+}

--- a/stellar-lend/contracts/hello-world/src/oracle.rs
+++ b/stellar-lend/contracts/hello-world/src/oracle.rs
@@ -161,7 +161,7 @@ const DEFAULT_MAX_STALENESS_SECONDS: u64 = 3600; // 1 hour
 const DEFAULT_CACHE_TTL_SECONDS: u64 = 300; // 5 minutes
 const DEFAULT_MIN_PRICE: i128 = 1;
 const DEFAULT_MAX_PRICE: i128 = i128::MAX;
-const DEFAULT_TWAP_WINDOW_SECONDS: u64 = 900; // 15 minutes
+const DEFAULT_TWAP_WINDOW_SECONDS: u64 = 1800; // 30 minutes
 const DEFAULT_MAX_OBSERVATIONS: u32 = 64;
 const DEFAULT_MIN_SOURCES: u32 = 1;
 const DEFAULT_OUTLIER_DEVIATION_BPS: i128 = 1000; // 10%
@@ -1198,6 +1198,99 @@ pub fn get_price(env: &Env, asset: &Address) -> Result<i128, OracleError> {
     record_safe_price(env, asset, twap);
 
     Ok(twap)
+}
+
+/// Get TWAP price specifically for liquidation pricing.
+///
+/// Liquidation pricing uses TWAP to resist short-term manipulation.
+/// When insufficient history exists for a full TWAP window, this function
+/// falls back to the spot price aggregated from multiple sources with
+/// outlier filtering (median across sources).
+///
+/// # Arguments
+/// * `env` - The Soroban environment
+/// * `asset` - The asset address
+///
+/// # Returns
+/// Returns the TWAP price or median spot price for liquidation calculations.
+pub fn get_liquidation_price(env: &Env, asset: &Address) -> Result<i128, OracleError> {
+    // Circuit breaker check first
+    if is_breaker_open(env, asset) {
+        return Err(OracleError::CircuitBreakerOpen);
+    }
+
+    // Try cache first (gas-efficient path)
+    if let Some(cached_price) = get_cached_price(env, asset) {
+        return Ok(cached_price);
+    }
+
+    let config = get_oracle_config(env);
+
+    // Try to compute TWAP first (most manipulation-resistant)
+    if config.twap_window_seconds > 0 {
+        let history = load_history(env, asset);
+        if !history.is_empty() {
+            // Use a spot-price anchor for TWAP computation
+            let spot = aggregate_spot_price(env, asset)?;
+            let twap = compute_twap(env, asset, spot)?;
+
+            // Validate TWAP isn't stale or extreme vs spot
+            if twap > 0 {
+                let deviation_bps = price_deviation_bps(spot, twap).unwrap_or(10000);
+                // If TWAP and spot are reasonably close, use TWAP
+                if deviation_bps <= config.breaker_deviation_bps {
+                    cache_price(env, asset, twap);
+                    record_safe_price(env, asset, twap);
+                    return Ok(twap);
+                }
+            }
+        }
+    }
+
+    // Fallback: median across multiple sources with outlier filtering
+    let spot = aggregate_spot_price(env, asset)?;
+
+    // Trip breaker check on the fallback price
+    maybe_trip_breaker(env, asset, spot)?;
+    if is_breaker_open(env, asset) {
+        return Err(OracleError::CircuitBreakerOpen);
+    }
+
+    cache_price(env, asset, spot);
+    record_safe_price(env, asset, spot);
+
+    Ok(spot)
+}
+
+/// Get raw spot price (non-TWAP) for an asset.
+/// Useful for display purposes or when instantaneous price is needed.
+pub fn get_spot_price(env: &Env, asset: &Address) -> Result<i128, OracleError> {
+    if is_breaker_open(env, asset) {
+        return Err(OracleError::CircuitBreakerOpen);
+    }
+
+    let spot = aggregate_spot_price(env, asset)?;
+    validate_price(env, spot)?;
+
+    Ok(spot)
+}
+
+/// Get the TWAP value for the current window without updating state.
+/// This is a read-only view function for off-chain monitoring.
+pub fn get_twap_view(env: &Env, asset: &Address) -> Result<i128, OracleError> {
+    let config = get_oracle_config(env);
+    if config.twap_window_seconds == 0 {
+        return aggregate_spot_price(env, asset);
+    }
+
+    let history = load_history(env, asset);
+    if history.is_empty() {
+        return aggregate_spot_price(env, asset);
+    }
+
+    // Use the latest observation as spot anchor for TWAP
+    let latest = history.get(history.len() - 1).unwrap();
+    compute_twap(env, asset, latest.price)
 }
 
 /// Get price from fallback oracle


### PR DESCRIPTION
Contract changes (oracle.rs):
- Changed default TWAP window from 15min to 30min for stronger manipulation resistance
- Added get_liquidation_price() - TWAP-based pricing with median fallback on manipulation
- Added get_spot_price() - raw spot price aggregation with outlier filtering
- Added get_twap_view() - read-only TWAP for off-chain monitoring

Off-chain oracle services:
- New TWAPService (twap.service.ts) - TWAP accumulator with:
  - Configurable 30min window, gas-efficient single-update-per-period
  - Deviation checks with automatic median fallback on manipulation
  - Liquidation pricing endpoint for lending protocol integration
- New ManipulationDetector (manipulation-detector.ts) with:
  - Source deviation monitoring with consecutive drift detection
  - TWAP/spot price deviation alerts
  - Volatility spike detection
  - Source availability tracking
- New shared price-math utility for precision-safe deviation calculations

API integration:
- Added get_liquidation_price to StellarService
- Added GET /lending/liquidation-price/:asset endpoint
- Uses contract's TWAP accumulator for manipulation-resistant liquidation pricing

## What Changed

Summarize the main code and behavior changes.

## Why

Explain the problem this PR solves.

## Testing

- [ ] Unit tests updated or added
- [ ] Relevant local checks passed
- [ ] Manual verification completed when needed

## Related Issues

Link the related issue(s), for example: 

Closes #325