### PR TITLE
fix(#327): fix rebalancing test module path from crate::reb to crate::rebalancing

### DIFF
--- a/stellar-lend/contracts/hello-world/src/tests/rebalancing_tests.rs
+++ b/stellar-lend/contracts/hello-world/src/tests/rebalancing_tests.rs
@@ -244,13 +244,13 @@ fn test_rebalancing_gas_cost_estimation() {
 fn is_emergency_stop_active(env: &Env) -> bool {
     env.storage()
         .persistent()
-        .get(&crate::reb::RebalancingDataKey::EmergencyStop)
+        .get(&crate::rebalancing::RebalancingDataKey::EmergencyStop)
         .unwrap_or(false)
 }
 
 fn is_rebalancing_paused(env: &Env) -> bool {
     env.storage()
         .persistent()
-        .get(&crate::reb::RebalancingDataKey::RebalancingPaused)
+        .get(&crate::rebalancing::RebalancingDataKey::RebalancingPaused)
         .unwrap_or(false)
 }


### PR DESCRIPTION
Closes #326

---

Closes #328

---

Closes #327

---

## Summary

Fixes a compilation bug in the rebalancing test suite where helper functions referenced `crate::reb::RebalancingDataKey` instead of the correct `crate::rebalancing::RebalancingDataKey`.

## Changes

### Bug Fix
- Fixed two occurrences in `rebalancing_tests.rs` helper functions `is_emergency_stop_active` and `is_rebalancing_paused`
- Changed `crate::reb::RebalancingDataKey::EmergencyStop` to `crate::rebalancing::RebalancingDataKey::EmergencyStop`
- Changed `crate::reb::RebalancingDataKey::RebalancingPaused` to `crate::rebalancing::RebalancingDataKey::RebalancingPaused`

### Impact
- The rebalancing test suite now correctly references the `rebalancing` module instead of the non-existent `reb` module
- Enables compilation of the full rebalancing test suite

### Files Changed
- `stellar-lend/contracts/hello-world/src/tests/rebalancing_tests.rs` - 2 line fixes