### PR TITLE
fix(#326): add role-based auth and daily spending limits to institutional wallet

### DIFF
--- a/stellar-lend/contracts/institutional-wallet/src/lib.rs
+++ b/stellar-lend/contracts/institutional-wallet/src/lib.rs
@@ -9,11 +9,14 @@ mod storage;
 mod test;
 
 use crate::types::{
-    AuditEntry, MultisigConfig, Proposal, ProposalStatus, Transaction, WalletError,
+    AuditEntry, DailySpendingLimit, MultisigConfig, Proposal, ProposalStatus, Transaction,
+    WalletError, WalletRole,
 };
 use crate::storage::{
-    add_audit_entry, get_admins, get_approvals, get_config, get_next_proposal_id, get_proposal,
-    increment_proposal_id, set_admins, set_approvals, set_config, set_proposal,
+    add_audit_entry, check_and_record_daily_spend, clear_daily_spend_tracking, get_admins,
+    get_approvals, get_config, get_next_proposal_id, get_proposal, get_role,
+    get_spending_limit_config, increment_proposal_id, remove_role, remove_spending_limit_config,
+    set_admins, set_approvals, set_config, set_proposal, set_role, set_spending_limit_config,
 };
 
 /// Emergency recovery timeout: 90 days without any admin activity.
@@ -42,9 +45,19 @@ impl InstitutionalWallet {
             return Err(WalletError::InvalidThreshold);
         }
 
-        let config = MultisigConfig { threshold };
+        let config = MultisigConfig {
+            threshold,
+            default_daily_spend_limit: 0,
+        };
         set_config(&env, &config);
         set_admins(&env, &admins);
+
+        // Assign Admin role to all initial admins
+        for i in 0..admins.len() {
+            if let Some(admin) = admins.get(i) {
+                set_role(&env, &admin, WalletRole::Admin);
+            }
+        }
         crate::storage::set_last_activity(&env, env.ledger().timestamp());
 
         Ok(())
@@ -62,6 +75,12 @@ impl InstitutionalWallet {
         let admins = get_admins(&env);
         if !admins.contains(proposer.clone()) {
             return Err(WalletError::Unauthorized);
+        }
+
+        // Role check: must be Admin or Approver to propose
+        let role = get_role(&env, &proposer).unwrap_or(WalletRole::Viewer);
+        if role != WalletRole::Admin && role != WalletRole::Approver {
+            return Err(WalletError::InsufficientRole);
         }
 
         if batch.is_empty() {
@@ -110,6 +129,12 @@ impl InstitutionalWallet {
             return Err(WalletError::Unauthorized);
         }
 
+        // Role check: must be Admin or Approver to approve
+        let role = get_role(&env, &approver).unwrap_or(WalletRole::Viewer);
+        if role != WalletRole::Admin && role != WalletRole::Approver {
+            return Err(WalletError::InsufficientRole);
+        }
+
         let proposal = get_proposal(&env, proposal_id).ok_or(WalletError::ProposalNotFound)?;
         if proposal.status != ProposalStatus::Active {
             return Err(WalletError::ProposalNotActive);
@@ -146,6 +171,12 @@ impl InstitutionalWallet {
             return Err(WalletError::Unauthorized);
         }
 
+        // Role check: must be Admin or Executor to execute
+        let role = get_role(&env, &executor).unwrap_or(WalletRole::Viewer);
+        if role != WalletRole::Admin && role != WalletRole::Executor {
+            return Err(WalletError::InsufficientRole);
+        }
+
         let mut proposal = get_proposal(&env, proposal_id).ok_or(WalletError::ProposalNotFound)?;
         if proposal.status != ProposalStatus::Active {
             return Err(WalletError::ProposalNotActive);
@@ -156,6 +187,14 @@ impl InstitutionalWallet {
 
         if approvals.len() < config.threshold {
             return Err(WalletError::InsufficientApprovals);
+        }
+
+        // Enforce daily spending limits per asset in the batch
+        for tx in proposal.batch.iter() {
+            if tx.spend_amount > 0 {
+                let asset = tx.spend_asset.clone().unwrap_or_else(|| tx.contract.clone());
+                check_and_record_daily_spend(&env, &asset, tx.spend_amount)?;
+            }
         }
 
         // Execute batch
@@ -237,6 +276,104 @@ impl InstitutionalWallet {
 
         let mut config = get_config(&env)?;
         config.threshold = threshold;
+        set_config(&env, &config);
+        Ok(())
+    }
+
+    // ─── Role Management (must be called via multisig execute) ───────────
+
+    /// Assign a role to an address (Admin only, via multisig).
+    pub fn assign_role(
+        env: Env,
+        addr: Address,
+        role: WalletRole,
+    ) -> Result<(), WalletError> {
+        env.current_contract_address().require_auth();
+
+        set_role(&env, &addr, role);
+
+        add_audit_entry(
+            &env,
+            0,
+            AuditEntry {
+                actor: addr,
+                action: symbol_short!("roleSet"),
+                timestamp: env.ledger().timestamp(),
+            },
+        );
+        Ok(())
+    }
+
+    /// Revoke a role from an address (Admin only, via multisig).
+    pub fn revoke_role(env: Env, addr: Address) -> Result<(), WalletError> {
+        env.current_contract_address().require_auth();
+
+        if get_role(&env, &addr).is_none() {
+            return Err(WalletError::RoleNotFound);
+        }
+
+        remove_role(&env, &addr);
+
+        add_audit_entry(
+            &env,
+            0,
+            AuditEntry {
+                actor: addr,
+                action: symbol_short!("roleRev"),
+                timestamp: env.ledger().timestamp(),
+            },
+        );
+        Ok(())
+    }
+
+    // ─── Spending Limit Management ───────────────────────────────────────
+
+    /// Set a daily spending limit for a specific asset (Admin only, via multisig).
+    pub fn set_daily_spending_limit(
+        env: Env,
+        asset: Address,
+        daily_limit: i128,
+    ) -> Result<(), WalletError> {
+        env.current_contract_address().require_auth();
+
+        if daily_limit < 0 {
+            return Err(WalletError::InvalidThreshold);
+        }
+
+        if daily_limit == 0 {
+            // Remove limit
+            remove_spending_limit_config(&env, &asset);
+            clear_daily_spend_tracking(&env, &asset);
+        } else {
+            let limit = DailySpendingLimit { daily_limit };
+            set_spending_limit_config(&env, &asset, &limit);
+        }
+
+        add_audit_entry(
+            &env,
+            0,
+            AuditEntry {
+                actor: asset,
+                action: symbol_short!("spendLim"),
+                timestamp: env.ledger().timestamp(),
+            },
+        );
+        Ok(())
+    }
+
+    /// Set the default daily spending limit for all assets (Admin only, via multisig).
+    pub fn set_default_spending_limit(
+        env: Env,
+        daily_limit: i128,
+    ) -> Result<(), WalletError> {
+        env.current_contract_address().require_auth();
+
+        if daily_limit < 0 {
+            return Err(WalletError::InvalidThreshold);
+        }
+
+        let mut config = get_config(&env)?;
+        config.default_daily_spend_limit = daily_limit;
         set_config(&env, &config);
         Ok(())
     }
@@ -577,5 +714,20 @@ impl InstitutionalWallet {
 
     pub fn get_last_activity(env: Env) -> u64 {
         crate::storage::get_last_activity(&env)
+    }
+
+    /// Get the role assigned to an address.
+    pub fn get_role(env: Env, addr: Address) -> Option<WalletRole> {
+        get_role(&env, &addr)
+    }
+
+    /// Get the daily spending limit config for an asset.
+    pub fn get_daily_spending_limit(env: Env, asset: Address) -> Option<DailySpendingLimit> {
+        get_spending_limit_config(&env, &asset)
+    }
+
+    /// Get the default daily spending limit.
+    pub fn get_default_spending_limit(env: Env) -> i128 {
+        get_config(&env).map(|c| c.default_daily_spend_limit).unwrap_or(0)
     }
 }

--- a/stellar-lend/contracts/institutional-wallet/src/storage.rs
+++ b/stellar-lend/contracts/institutional-wallet/src/storage.rs
@@ -1,5 +1,5 @@
 use soroban_sdk::{Address, Env, Vec};
-use crate::types::{DataKey, MultisigConfig, Proposal, AuditEntry, WalletError};
+use crate::types::{DailySpendingLimit, DataKey, MultisigConfig, Proposal, AuditEntry, WalletError, WalletRole};
 
 pub fn get_config(env: &Env) -> Result<MultisigConfig, WalletError> {
     env.storage()
@@ -130,4 +130,101 @@ pub fn get_guardian_acceptance(env: &Env, guardian: &Address) -> bool {
 
 pub fn set_guardian_acceptance(env: &Env, guardian: Address, accepted: bool) {
     env.storage().instance().set(&DataKey::GuardianAcceptances(guardian), &accepted);
+}
+
+// ─── Role-Based Authorization ─────────────────────────────────────────────
+
+/// Get the role assigned to an address. Returns `None` if address has no role.
+pub fn get_role(env: &Env, addr: &Address) -> Option<WalletRole> {
+    env.storage().instance().get(&DataKey::RoleAssignments(addr.clone()))
+}
+
+/// Set a role for an address.
+pub fn set_role(env: &Env, addr: &Address, role: WalletRole) {
+    env.storage().instance().set(&DataKey::RoleAssignments(addr.clone()), &role);
+}
+
+/// Remove a role assignment for an address.
+pub fn remove_role(env: &Env, addr: &Address) {
+    env.storage().instance().remove(&DataKey::RoleAssignments(addr.clone()));
+}
+
+/// Remove daily spending limit config for an asset.
+pub fn remove_spending_limit_config(env: &Env, asset: &Address) {
+    env.storage().instance().remove(&DataKey::SpendingLimitConfig(asset.clone()));
+}
+
+// ─── Daily Spending Limits ────────────────────────────────────────────────
+
+const SECONDS_PER_DAY: u64 = 86400;
+
+/// Get the day number for a given timestamp.
+fn day_number(timestamp: u64) -> u64 {
+    timestamp / SECONDS_PER_DAY
+}
+
+/// Get the configured daily spending limit for an asset.
+pub fn get_spending_limit_config(env: &Env, asset: &Address) -> Option<DailySpendingLimit> {
+    env.storage().instance().get(&DataKey::SpendingLimitConfig(asset.clone()))
+}
+
+/// Set the daily spending limit configuration for an asset.
+pub fn set_spending_limit_config(env: &Env, asset: &Address, limit: &DailySpendingLimit) {
+    env.storage().instance().set(&DataKey::SpendingLimitConfig(asset.clone()), limit);
+}
+
+/// Clear today's spending tracking for an asset (used on limit removal).
+pub fn clear_daily_spend_tracking(env: &Env, asset: &Address) {
+    let now = env.ledger().timestamp();
+    let current_day = now / SECONDS_PER_DAY;
+    env.storage().instance().remove(&DataKey::DailySpending(asset.clone(), current_day));
+}
+
+/// Check if spending `amount` for `asset` would exceed the daily limit.
+/// If within limit, updates the spent-today tracking and returns Ok.
+/// If over limit, returns Err(SpendingLimitExceeded).
+pub fn check_and_record_daily_spend(
+    env: &Env,
+    asset: &Address,
+    amount: i128,
+) -> Result<(), WalletError> {
+    if amount <= 0 {
+        return Ok(()); // Nothing to check
+    }
+
+    let daily_limit = match get_spending_limit_config(env, asset) {
+        Some(cfg) => cfg.daily_limit,
+        None => {
+            // No per-asset limit; check default from multisig config
+            let config = get_config(env)?;
+            config.default_daily_spend_limit
+        }
+    };
+
+    if daily_limit == 0 {
+        return Ok(()); // Unlimited
+    }
+
+    let now = env.ledger().timestamp();
+    let current_day = now / SECONDS_PER_DAY;
+
+    let spent_today: i128 = env
+        .storage()
+        .instance()
+        .get(&DataKey::DailySpending(asset.clone(), current_day))
+        .unwrap_or(0);
+
+    let new_total = spent_today
+        .checked_add(amount)
+        .ok_or(WalletError::ExecutionFailed)?;
+
+    if new_total > daily_limit {
+        return Err(WalletError::SpendingLimitExceeded);
+    }
+
+    env.storage()
+        .instance()
+        .set(&DataKey::DailySpending(asset.clone(), current_day), &new_total);
+
+    Ok(())
 }

--- a/stellar-lend/contracts/institutional-wallet/src/test.rs
+++ b/stellar-lend/contracts/institutional-wallet/src/test.rs
@@ -1,7 +1,7 @@
 #![cfg(test)]
 
 use super::*;
-use soroban_sdk::{testutils::{Address as _, Ledger}, vec, Address, Env, String, symbol_short};
+use soroban_sdk::{testutils::{Address as _, Ledger}, vec, Address, Env, String, Symbol, symbol_short};
 use crate::types::{Transaction, ProposalStatus};
 
 #[test]
@@ -36,6 +36,8 @@ fn test_propose_and_approve() {
         contract: Address::generate(&env),
         function: symbol_short!("test"),
         args: vec![&env],
+        spend_amount: 0,
+        spend_asset: None,
     };
     let batch = vec![&env, tx];
     
@@ -74,6 +76,8 @@ fn test_execute_insufficient_approvals() {
         contract: Address::generate(&env),
         function: symbol_short!("test"),
         args: vec![&env],
+        spend_amount: 0,
+        spend_asset: None,
     };
     let batch = vec![&env, tx];
     
@@ -157,6 +161,8 @@ fn test_recovery_flow() {
         contract: contract_id.clone(),
         function: Symbol::new(&env, "set_guardians"),
         args: (guardians.clone(), 1u32).into_val(&env),
+        spend_amount: 0,
+        spend_asset: None,
     };
     let batch = vec![&env, tx];
     let proposal_id = client.propose(&admin1, &String::from_str(&env, "Set guardians"), &batch);

--- a/stellar-lend/contracts/institutional-wallet/src/types.rs
+++ b/stellar-lend/contracts/institutional-wallet/src/types.rs
@@ -1,5 +1,27 @@
 use soroban_sdk::{contracterror, contracttype, Address, BytesN, String, Vec, Val};
 
+/// Role-based authorization levels for institutional wallet operations.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq, Copy)]
+pub enum WalletRole {
+    /// Full access: manage signers, thresholds, roles, and spending limits
+    Admin = 0,
+    /// Can propose and approve transactions
+    Approver = 1,
+    /// Can execute approved proposals
+    Executor = 2,
+    /// Read-only access to wallet state
+    Viewer = 3,
+}
+
+/// Per-asset daily spending limit configuration.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DailySpendingLimit {
+    /// Maximum amount that can be spent per day for this asset (0 = unlimited)
+    pub daily_limit: i128,
+}
+
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]
@@ -22,6 +44,12 @@ pub enum WalletError {
     GuardianRotationFailed = 16,
     EmergencyTimeoutActive = 17,
     RecoveryCancelledByOwner = 18,
+    /// Spending limit exceeded for the current day
+    SpendingLimitExceeded = 19,
+    /// Role assignment not found
+    RoleNotFound = 20,
+    /// Insufficient role for operation
+    InsufficientRole = 21,
 }
 
 #[contracttype]
@@ -41,6 +69,12 @@ pub enum DataKey {
     LastActivity,
     GuardianApprovals,
     RecoveryCancelRequest,
+    /// Role assignment per admin: RoleAssignments(Address) -> WalletRole
+    RoleAssignments(Address),
+    /// Daily spending limit per asset: DailySpending(asset Address, day u64) -> i128
+    DailySpending(Address, u64),
+    /// Spending limit config per asset: SpendingLimitConfig(Address) -> DailySpendingLimit
+    SpendingLimitConfig(Address),
 }
 
 #[contracttype]
@@ -55,6 +89,8 @@ pub struct RecoveryRequest {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MultisigConfig {
     pub threshold: u32,
+    /// Default daily spending limit for all assets (0 = unlimited)
+    pub default_daily_spend_limit: i128,
 }
 
 #[contracttype]
@@ -63,6 +99,10 @@ pub struct Transaction {
     pub contract: Address,
     pub function: soroban_sdk::Symbol,
     pub args: Vec<Val>,
+    /// Optional spending amount for daily limit enforcement (0 = no limit check)
+    pub spend_amount: i128,
+    /// Asset to check spending limit against (only used when spend_amount > 0)
+    pub spend_asset: Option<Address>,
 }
 
 #[contracttype]


### PR DESCRIPTION
## Summary

Implements role-based authorization and daily spending limits for the institutional-grade multisig wallet, completing the remaining acceptance criteria for issue #326.

## Changes

### New Features
- **WalletRole enum** (Admin, Approver, Executor, Viewer) with role-based access control
- **DailySpendingLimit** per-asset spending cap configuration
- **Role enforcement** in `propose()`, `approve()`, and `execute()` entrypoints
- **Spending limit enforcement** in `execute()` using the new `Transaction.spend_amount` and `Transaction.spend_asset` fields

### New Entrypoints
- `assign_role(addr, role)` - Assign a role to an address (admin only, via multisig)
- `revoke_role(addr)` - Remove a role assignment
- `set_daily_spending_limit(asset, daily_limit)` - Set per-asset daily spending cap
- `set_default_spending_limit(daily_limit)` - Set default spending cap for all assets
- `get_role(addr)`, `get_daily_spending_limit(asset)`, `get_default_spending_limit()` - View functions

### Bug Fix
- Fixed test.rs: added missing `Symbol` import for `Symbol::new` usage in recovery tests
- Updated Transaction struct with `spend_amount` and `spend_asset` optional fields

### Files Changed
- `stellar-lend/contracts/institutional-wallet/src/types.rs` - Added WalletRole, DailySpendingLimit, new errors, Transaction fields
- `stellar-lend/contracts/institutional-wallet/src/storage.rs` - Added role limit storage functions
- `stellar-lend/contracts/institutional-wallet/src/lib.rs` - Role limit entrypoints
- `stellar-lend/contracts/institutional-wallet/src/test.rs` - Fixed Symbol import