### PR TITLE
feat: extract frontend lending components into reusable SDK package

### DIFF
--- a/packages/ui-lending/package.json
+++ b/packages/ui-lending/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@stellarlend/ui-lending",
+  "version": "0.1.0",
+  "description": "Reusable lending UI components, hooks, and utilities for StellarLend",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "test": "jest",
+    "storybook": "storybook dev -p 6006",
+    "build-storybook": "storybook build"
+  },
+  "peerDependencies": {
+    "react": ">=18.0.0",
+    "react-dom": ">=18.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0",
+    "typescript": "^5.0.0"
+  },
+  "keywords": ["stellar", "lending", "defi", "react", "components"],
+  "license": "MIT"
+}

--- a/packages/ui-lending/src/components/HealthMeter/index.tsx
+++ b/packages/ui-lending/src/components/HealthMeter/index.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import type { HealthFactor, LendingTheme } from '../../types';
+import { LIGHT_COLORS, getHealthColor } from '../../utils/theme';
+
+interface HealthMeterProps {
+  health: HealthFactor;
+  theme?: LendingTheme;
+  showDetails?: boolean;
+  isLoading?: boolean;
+  className?: string;
+}
+
+/**
+ * HealthMeter — visual gauge for account health factor.
+ * Green ≥ 2.0, Yellow ≥ 1.5, Red < 1.5, Critical < 1.0.
+ */
+export function HealthMeter({
+  health,
+  theme,
+  showDetails = true,
+  isLoading = false,
+  className = '',
+}: HealthMeterProps) {
+  const colors = theme?.colors ?? LIGHT_COLORS;
+  const healthColor = getHealthColor(health.value, colors);
+  const percentage = Math.min(100, (health.value / 3) * 100);
+
+  if (isLoading) {
+    return (
+      <div className={`health-meter ${className}`} style={{ padding: 16, background: colors.surface, borderRadius: 12, border: `1px solid ${colors.border}` }}>
+        <div style={{ height: 12, background: colors.border, borderRadius: 6 }} />
+      </div>
+    );
+  }
+
+  return (
+    <div className={`health-meter ${className}`} style={{ padding: 16, background: colors.surface, borderRadius: 12, border: `1px solid ${colors.border}` }} data-testid="health-meter">
+      <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 8 }}>
+        <span style={{ color: colors.textMuted, fontSize: 13 }}>Health Factor</span>
+        <span style={{ color: healthColor, fontWeight: 700, fontSize: 18 }}>
+          {health.value === Infinity ? '∞' : health.value.toFixed(2)}
+        </span>
+      </div>
+
+      <div style={{ height: 8, background: colors.border, borderRadius: 4, overflow: 'hidden', marginBottom: 12 }}>
+        <div style={{ height: '100%', width: `${percentage}%`, background: healthColor, borderRadius: 4, transition: 'width 0.3s ease' }} />
+      </div>
+
+      <div style={{ display: 'flex', justifyContent: 'center' }}>
+        <span style={{ fontSize: 12, color: healthColor, fontWeight: 600, textTransform: 'uppercase' }}>
+          {health.status}
+        </span>
+      </div>
+
+      {showDetails && (
+        <div style={{ marginTop: 12, display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 }}>
+          <div>
+            <div style={{ color: colors.textMuted, fontSize: 11 }}>Collateral Value</div>
+            <div style={{ color: colors.text, fontSize: 13, fontWeight: 500 }}>${health.collateralValue.toFixed(2)}</div>
+          </div>
+          <div>
+            <div style={{ color: colors.textMuted, fontSize: 11 }}>Borrowed Value</div>
+            <div style={{ color: colors.text, fontSize: 13, fontWeight: 500 }}>${health.borrowedValue.toFixed(2)}</div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/ui-lending/src/components/LiquidationRiskGauge/index.tsx
+++ b/packages/ui-lending/src/components/LiquidationRiskGauge/index.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import type { LiquidationRisk, LendingTheme } from '../../types';
+import { LIGHT_COLORS, getRiskColor } from '../../utils/theme';
+
+interface LiquidationRiskGaugeProps {
+  risk: LiquidationRisk;
+  theme?: LendingTheme;
+  isLoading?: boolean;
+  className?: string;
+}
+
+/**
+ * LiquidationRiskGauge — displays liquidation risk with price buffer visualization.
+ */
+export function LiquidationRiskGauge({ risk, theme, isLoading = false, className = '' }: LiquidationRiskGaugeProps) {
+  const colors = theme?.colors ?? LIGHT_COLORS;
+  const riskColor = getRiskColor(risk.riskLevel, colors);
+  const bufferPct = Math.max(0, Math.min(100, risk.safetyBuffer * 100));
+
+  if (isLoading) {
+    return (
+      <div className={`liquidation-gauge ${className}`} style={{ padding: 16, background: colors.surface, borderRadius: 12, border: `1px solid ${colors.border}` }}>
+        <div style={{ height: 12, background: colors.border, borderRadius: 6 }} />
+      </div>
+    );
+  }
+
+  return (
+    <div className={`liquidation-gauge ${className}`} style={{ padding: 16, background: colors.surface, borderRadius: 12, border: `1px solid ${colors.border}` }} data-testid="liquidation-gauge">
+      <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 12 }}>
+        <span style={{ color: colors.text, fontWeight: 600 }}>Liquidation Risk</span>
+        <span style={{ color: riskColor, fontWeight: 700, textTransform: 'uppercase', fontSize: 13 }}>{risk.riskLevel}</span>
+      </div>
+
+      <div style={{ height: 10, background: colors.border, borderRadius: 5, overflow: 'hidden', marginBottom: 16 }}>
+        <div style={{ height: '100%', width: `${bufferPct}%`, background: riskColor, borderRadius: 5, transition: 'width 0.3s ease' }} />
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 }}>
+        <div>
+          <div style={{ color: colors.textMuted, fontSize: 11 }}>Current Price</div>
+          <div style={{ color: colors.text, fontWeight: 500 }}>${risk.currentPrice.toFixed(2)}</div>
+        </div>
+        <div>
+          <div style={{ color: colors.textMuted, fontSize: 11 }}>Liquidation Price</div>
+          <div style={{ color: colors.danger, fontWeight: 500 }}>${risk.liquidationPrice.toFixed(2)}</div>
+        </div>
+        <div>
+          <div style={{ color: colors.textMuted, fontSize: 11 }}>Safety Buffer</div>
+          <div style={{ color: riskColor, fontWeight: 500 }}>{(risk.safetyBuffer * 100).toFixed(1)}%</div>
+        </div>
+        <div>
+          <div style={{ color: colors.textMuted, fontSize: 11 }}>Health Factor</div>
+          <div style={{ color: riskColor, fontWeight: 500 }}>{risk.healthFactor.toFixed(2)}</div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui-lending/src/components/PoolCard/index.tsx
+++ b/packages/ui-lending/src/components/PoolCard/index.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import type { PoolData, LendingTheme } from '../../types';
+import { LIGHT_COLORS } from '../../utils/theme';
+
+interface PoolCardProps {
+  pool: PoolData;
+  theme?: LendingTheme;
+  onSupply?: (pool: PoolData) => void;
+  onBorrow?: (pool: PoolData) => void;
+  isLoading?: boolean;
+  className?: string;
+}
+
+/**
+ * PoolCard — displays a lending pool with utilization, APY, and actions.
+ */
+export function PoolCard({ pool, theme, onSupply, onBorrow, isLoading = false, className = '' }: PoolCardProps) {
+  const colors = theme?.colors ?? LIGHT_COLORS;
+
+  if (isLoading) {
+    return (
+      <div className={`pool-card ${className}`} style={{ background: colors.surface, border: `1px solid ${colors.border}`, borderRadius: 12, padding: 20 }} role="status">
+        <div style={{ height: 16, background: colors.border, borderRadius: 4, marginBottom: 8, width: '50%' }} />
+        <div style={{ height: 12, background: colors.border, borderRadius: 4, width: '70%' }} />
+      </div>
+    );
+  }
+
+  if (!pool.isActive) {
+    return (
+      <div className={`pool-card pool-card--inactive ${className}`} style={{ background: colors.surface, border: `1px solid ${colors.border}`, borderRadius: 12, padding: 20, opacity: 0.5 }} data-testid="pool-card-inactive">
+        <h3 style={{ color: colors.text, margin: 0 }}>{pool.asset}</h3>
+        <span style={{ color: colors.textMuted, fontSize: 13 }}>Pool inactive</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`pool-card ${className}`} style={{ background: colors.surface, border: `1px solid ${colors.border}`, borderRadius: 12, padding: 20 }} data-testid="pool-card">
+      <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 16 }}>
+        <div>
+          <h3 style={{ color: colors.text, margin: 0 }}>{pool.asset}</h3>
+          <span style={{ color: colors.textMuted, fontSize: 13 }}>{pool.symbol}</span>
+        </div>
+        <div style={{ textAlign: 'right' }}>
+          <div style={{ color: colors.textMuted, fontSize: 11 }}>Utilization</div>
+          <div style={{ color: colors.primary, fontWeight: 600 }}>{(pool.utilization * 100).toFixed(1)}%</div>
+        </div>
+      </div>
+
+      <div style={{ height: 6, background: colors.border, borderRadius: 3, marginBottom: 16 }}>
+        <div style={{ height: '100%', width: `${pool.utilization * 100}%`, background: colors.primary, borderRadius: 3 }} />
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12, marginBottom: 16 }}>
+        <div>
+          <div style={{ color: colors.textMuted, fontSize: 11 }}>Supply APY</div>
+          <div style={{ color: colors.success, fontWeight: 600 }}>{pool.supplyApy.toFixed(2)}%</div>
+        </div>
+        <div>
+          <div style={{ color: colors.textMuted, fontSize: 11 }}>Borrow APY</div>
+          <div style={{ color: colors.danger, fontWeight: 600 }}>{pool.borrowApy.toFixed(2)}%</div>
+        </div>
+        <div>
+          <div style={{ color: colors.textMuted, fontSize: 11 }}>Total Supply</div>
+          <div style={{ color: colors.text, fontSize: 13 }}>${pool.totalSupply.toLocaleString()}</div>
+        </div>
+        <div>
+          <div style={{ color: colors.textMuted, fontSize: 11 }}>Total Borrow</div>
+          <div style={{ color: colors.text, fontSize: 13 }}>${pool.totalBorrow.toLocaleString()}</div>
+        </div>
+      </div>
+
+      <div style={{ display: 'flex', gap: 8 }}>
+        {onSupply && (
+          <button onClick={() => onSupply(pool)} style={{ flex: 1, padding: '8px 12px', background: colors.primary, color: '#fff', border: 'none', borderRadius: 8, cursor: 'pointer', fontSize: 13 }}>Supply</button>
+        )}
+        {onBorrow && (
+          <button onClick={() => onBorrow(pool)} style={{ flex: 1, padding: '8px 12px', background: colors.surface, color: colors.text, border: `1px solid ${colors.border}`, borderRadius: 8, cursor: 'pointer', fontSize: 13 }}>Borrow</button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/ui-lending/src/components/PositionCard/PositionCard.test.tsx
+++ b/packages/ui-lending/src/components/PositionCard/PositionCard.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { PositionCard } from './index';
+
+const mockPosition = {
+  id: '1',
+  asset: 'USDC',
+  symbol: 'USDC',
+  supplied: 1000,
+  borrowed: 250,
+  supplyApy: 4.5,
+  borrowApy: 6.2,
+  collateralFactor: 0.8,
+  price: 1,
+};
+
+describe('PositionCard', () => {
+  it('renders asset name and symbol', () => {
+    render(<PositionCard position={mockPosition} />);
+    expect(screen.getByText('USDC')).toBeTruthy();
+  });
+
+  it('shows loading skeleton when isLoading is true', () => {
+    render(<PositionCard position={mockPosition} isLoading />);
+    expect(screen.getByRole('status')).toBeTruthy();
+  });
+
+  it('calls onSupply when supply button clicked', () => {
+    const onSupply = jest.fn();
+    render(<PositionCard position={mockPosition} onSupply={onSupply} />);
+    fireEvent.click(screen.getByText('Supply'));
+    expect(onSupply).toHaveBeenCalledWith(mockPosition);
+  });
+
+  it('calls onBorrow when borrow button clicked', () => {
+    const onBorrow = jest.fn();
+    render(<PositionCard position={mockPosition} onBorrow={onBorrow} />);
+    fireEvent.click(screen.getByText('Borrow'));
+    expect(onBorrow).toHaveBeenCalledWith(mockPosition);
+  });
+
+  it('renders supplied and borrowed amounts', () => {
+    render(<PositionCard position={mockPosition} />);
+    expect(screen.getByText('1000.0000')).toBeTruthy();
+    expect(screen.getByText('250.0000')).toBeTruthy();
+  });
+});

--- a/packages/ui-lending/src/components/PositionCard/index.tsx
+++ b/packages/ui-lending/src/components/PositionCard/index.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import type { Position, LendingTheme } from '../../types';
+import { LIGHT_COLORS } from '../../utils/theme';
+
+interface PositionCardProps {
+  position: Position;
+  theme?: LendingTheme;
+  onSupply?: (position: Position) => void;
+  onBorrow?: (position: Position) => void;
+  onRepay?: (position: Position) => void;
+  onWithdraw?: (position: Position) => void;
+  isLoading?: boolean;
+  className?: string;
+}
+
+/**
+ * PositionCard — displays a single lending position with supply/borrow details.
+ * Supports dark/light theming and loading/empty states.
+ */
+export function PositionCard({
+  position,
+  theme,
+  onSupply,
+  onBorrow,
+  onRepay,
+  onWithdraw,
+  isLoading = false,
+  className = '',
+}: PositionCardProps) {
+  const colors = theme?.colors ?? LIGHT_COLORS;
+
+  if (isLoading) {
+    return (
+      <div
+        className={`position-card position-card--loading ${className}`}
+        style={{ background: colors.surface, border: `1px solid ${colors.border}`, borderRadius: 12, padding: 20 }}
+        role="status"
+        aria-label="Loading position"
+      >
+        <div style={{ height: 16, background: colors.border, borderRadius: 4, marginBottom: 8, width: '60%' }} />
+        <div style={{ height: 12, background: colors.border, borderRadius: 4, width: '40%' }} />
+      </div>
+    );
+  }
+
+  const netValue = (position.supplied - position.borrowed) * position.price;
+
+  return (
+    <div
+      className={`position-card ${className}`}
+      style={{ background: colors.surface, border: `1px solid ${colors.border}`, borderRadius: 12, padding: 20 }}
+      data-testid="position-card"
+    >
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 }}>
+        <div>
+          <h3 style={{ color: colors.text, margin: 0, fontSize: 18, fontWeight: 600 }}>{position.asset}</h3>
+          <span style={{ color: colors.textMuted, fontSize: 13 }}>{position.symbol}</span>
+        </div>
+        <span style={{ color: netValue >= 0 ? colors.success : colors.danger, fontWeight: 600 }}>
+          ${netValue.toFixed(2)}
+        </span>
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12, marginBottom: 16 }}>
+        <div>
+          <div style={{ color: colors.textMuted, fontSize: 12, marginBottom: 4 }}>Supplied</div>
+          <div style={{ color: colors.text, fontWeight: 500 }}>{position.supplied.toFixed(4)}</div>
+          <div style={{ color: colors.success, fontSize: 12 }}>{position.supplyApy.toFixed(2)}% APY</div>
+        </div>
+        <div>
+          <div style={{ color: colors.textMuted, fontSize: 12, marginBottom: 4 }}>Borrowed</div>
+          <div style={{ color: colors.text, fontWeight: 500 }}>{position.borrowed.toFixed(4)}</div>
+          <div style={{ color: colors.danger, fontSize: 12 }}>{position.borrowApy.toFixed(2)}% APY</div>
+        </div>
+      </div>
+
+      <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+        {onSupply && (
+          <button onClick={() => onSupply(position)} style={{ flex: 1, padding: '8px 12px', background: colors.primary, color: '#fff', border: 'none', borderRadius: 8, cursor: 'pointer', fontSize: 13 }}>
+            Supply
+          </button>
+        )}
+        {onBorrow && (
+          <button onClick={() => onBorrow(position)} style={{ flex: 1, padding: '8px 12px', background: colors.secondary, color: '#fff', border: 'none', borderRadius: 8, cursor: 'pointer', fontSize: 13 }}>
+            Borrow
+          </button>
+        )}
+        {onRepay && position.borrowed > 0 && (
+          <button onClick={() => onRepay(position)} style={{ flex: 1, padding: '8px 12px', background: colors.warning, color: '#fff', border: 'none', borderRadius: 8, cursor: 'pointer', fontSize: 13 }}>
+            Repay
+          </button>
+        )}
+        {onWithdraw && position.supplied > 0 && (
+          <button onClick={() => onWithdraw(position)} style={{ flex: 1, padding: '8px 12px', background: colors.surface, color: colors.text, border: `1px solid ${colors.border}`, borderRadius: 8, cursor: 'pointer', fontSize: 13 }}>
+            Withdraw
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/ui-lending/src/components/RateChart/index.tsx
+++ b/packages/ui-lending/src/components/RateChart/index.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import type { RatePoint, LendingTheme } from '../../types';
+import { LIGHT_COLORS } from '../../utils/theme';
+
+interface RateChartProps {
+  data: RatePoint[];
+  theme?: LendingTheme;
+  showSupply?: boolean;
+  showBorrow?: boolean;
+  height?: number;
+  isLoading?: boolean;
+  isEmpty?: boolean;
+  className?: string;
+}
+
+/**
+ * RateChart — sparkline chart for supply/borrow APY over time.
+ * Pure SVG, no external chart library dependency.
+ */
+export function RateChart({
+  data,
+  theme,
+  showSupply = true,
+  showBorrow = true,
+  height = 120,
+  isLoading = false,
+  isEmpty = false,
+  className = '',
+}: RateChartProps) {
+  const colors = theme?.colors ?? LIGHT_COLORS;
+  const width = 300;
+
+  if (isLoading) {
+    return (
+      <div className={`rate-chart ${className}`} style={{ background: colors.surface, borderRadius: 12, padding: 16, border: `1px solid ${colors.border}` }}>
+        <div style={{ height, background: colors.border, borderRadius: 8 }} />
+      </div>
+    );
+  }
+
+  if (isEmpty || data.length === 0) {
+    return (
+      <div className={`rate-chart rate-chart--empty ${className}`} style={{ background: colors.surface, borderRadius: 12, padding: 16, border: `1px solid ${colors.border}`, height, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <span style={{ color: colors.textMuted, fontSize: 13 }}>No rate data available</span>
+      </div>
+    );
+  }
+
+  const maxApy = Math.max(...data.flatMap(d => [d.supplyApy, d.borrowApy]));
+  const minApy = Math.min(...data.flatMap(d => [d.supplyApy, d.borrowApy]));
+  const range = maxApy - minApy || 1;
+
+  const toX = (i: number) => (i / (data.length - 1)) * width;
+  const toY = (v: number) => height - ((v - minApy) / range) * (height - 20) - 10;
+
+  const supplyPath = data.map((d, i) => `${i === 0 ? 'M' : 'L'} ${toX(i)} ${toY(d.supplyApy)}`).join(' ');
+  const borrowPath = data.map((d, i) => `${i === 0 ? 'M' : 'L'} ${toX(i)} ${toY(d.borrowApy)}`).join(' ');
+
+  return (
+    <div className={`rate-chart ${className}`} style={{ background: colors.surface, borderRadius: 12, padding: 16, border: `1px solid ${colors.border}` }} data-testid="rate-chart">
+      <div style={{ display: 'flex', gap: 16, marginBottom: 8 }}>
+        {showSupply && <span style={{ fontSize: 12, color: colors.success }}>● Supply APY</span>}
+        {showBorrow && <span style={{ fontSize: 12, color: colors.danger }}>● Borrow APY</span>}
+      </div>
+      <svg width="100%" viewBox={`0 0 ${width} ${height}`} style={{ overflow: 'visible' }}>
+        {showSupply && <path d={supplyPath} fill="none" stroke={colors.success} strokeWidth={2} />}
+        {showBorrow && <path d={borrowPath} fill="none" stroke={colors.danger} strokeWidth={2} />}
+      </svg>
+    </div>
+  );
+}

--- a/packages/ui-lending/src/hooks/useHealthFactor.ts
+++ b/packages/ui-lending/src/hooks/useHealthFactor.ts
@@ -1,0 +1,36 @@
+import { useState, useCallback } from 'react';
+import type { HealthFactor, Position } from '../types';
+
+function computeHealthStatus(value: number): HealthFactor['status'] {
+  if (value >= 2) return 'safe';
+  if (value >= 1.5) return 'warning';
+  if (value >= 1) return 'danger';
+  return 'liquidatable';
+}
+
+/**
+ * useHealthFactor — compute and track account health factor from positions.
+ */
+export function useHealthFactor(positions: Position[] = []) {
+  const [isLoading, setIsLoading] = useState(false);
+
+  const compute = useCallback((): HealthFactor => {
+    if (positions.length === 0) {
+      return { value: Infinity, status: 'safe', collateralValue: 0, borrowedValue: 0, liquidationThreshold: 0.8 };
+    }
+
+    const collateralValue = positions.reduce(
+      (sum, p) => sum + p.supplied * p.price * p.collateralFactor, 0
+    );
+    const borrowedValue = positions.reduce(
+      (sum, p) => sum + p.borrowed * p.price, 0
+    );
+
+    const liquidationThreshold = 0.8;
+    const value = borrowedValue === 0 ? Infinity : (collateralValue * liquidationThreshold) / borrowedValue;
+
+    return { value, status: computeHealthStatus(value), collateralValue, borrowedValue, liquidationThreshold };
+  }, [positions]);
+
+  return { healthFactor: compute(), isLoading };
+}

--- a/packages/ui-lending/src/hooks/usePoolData.ts
+++ b/packages/ui-lending/src/hooks/usePoolData.ts
@@ -1,0 +1,22 @@
+import { useState, useCallback } from 'react';
+import type { PoolData } from '../types';
+
+/**
+ * usePoolData — manage pool data state with filtering and sorting.
+ */
+export function usePoolData(initialPools: PoolData[] = []) {
+  const [pools, setPools] = useState<PoolData[]>(initialPools);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const getActivesPools = useCallback(() => pools.filter(p => p.isActive), [pools]);
+
+  const getPoolById = useCallback((id: string) => pools.find(p => p.id === id) ?? null, [pools]);
+
+  const sortByApy = useCallback((type: 'supply' | 'borrow' = 'supply') =>
+    [...pools].sort((a, b) =>
+      type === 'supply' ? b.supplyApy - a.supplyApy : b.borrowApy - a.borrowApy
+    ), [pools]);
+
+  return { pools, isLoading, error, setPools, getActivesPools, getPoolById, sortByApy, setIsLoading, setError };
+}

--- a/packages/ui-lending/src/hooks/usePosition.ts
+++ b/packages/ui-lending/src/hooks/usePosition.ts
@@ -1,0 +1,26 @@
+import { useState, useCallback } from 'react';
+import type { Position } from '../types';
+
+interface UsePositionOptions {
+  onError?: (error: Error) => void;
+}
+
+/**
+ * usePosition — manage a single lending position with optimistic updates.
+ */
+export function usePosition(initialPosition?: Position, options: UsePositionOptions = {}) {
+  const [position, setPosition] = useState<Position | null>(initialPosition ?? null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const update = useCallback((updates: Partial<Position>) => {
+    setPosition(prev => prev ? { ...prev, ...updates } : null);
+  }, []);
+
+  const reset = useCallback(() => {
+    setPosition(initialPosition ?? null);
+    setError(null);
+  }, [initialPosition]);
+
+  return { position, isLoading, error, update, reset, setIsLoading, setError };
+}

--- a/packages/ui-lending/src/hooks/useRates.ts
+++ b/packages/ui-lending/src/hooks/useRates.ts
@@ -1,0 +1,22 @@
+import { useState, useCallback } from 'react';
+import type { RatePoint } from '../types';
+
+/**
+ * useRates — manage historical rate data for a pool.
+ */
+export function useRates(initialData: RatePoint[] = []) {
+  const [data, setData] = useState<RatePoint[]>(initialData);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const getLatest = useCallback((): RatePoint | null =>
+    data.length > 0 ? data[data.length - 1] : null, [data]);
+
+  const getAverageApy = useCallback((type: 'supply' | 'borrow' = 'supply') => {
+    if (data.length === 0) return 0;
+    const sum = data.reduce((s, d) => s + (type === 'supply' ? d.supplyApy : d.borrowApy), 0);
+    return sum / data.length;
+  }, [data]);
+
+  return { data, isLoading, error, setData, getLatest, getAverageApy, setIsLoading, setError };
+}

--- a/packages/ui-lending/src/index.ts
+++ b/packages/ui-lending/src/index.ts
@@ -1,0 +1,31 @@
+// Components
+export { PositionCard } from './components/PositionCard';
+export { HealthMeter } from './components/HealthMeter';
+export { RateChart } from './components/RateChart';
+export { PoolCard } from './components/PoolCard';
+export { LiquidationRiskGauge } from './components/LiquidationRiskGauge';
+
+// Hooks
+export { usePosition } from './hooks/usePosition';
+export { usePoolData } from './hooks/usePoolData';
+export { useHealthFactor } from './hooks/useHealthFactor';
+export { useRates } from './hooks/useRates';
+
+// Store
+export { usePositionStore } from './store/positionStore';
+export { usePoolStore } from './store/poolStore';
+
+// Types
+export type {
+  Position,
+  PoolData,
+  HealthFactor,
+  RatePoint,
+  LiquidationRisk,
+  LendingTheme,
+  Theme,
+  ThemeColors,
+} from './types';
+
+// Utils
+export { createTheme, getHealthColor, getRiskColor, LIGHT_COLORS, DARK_COLORS } from './utils/theme';

--- a/packages/ui-lending/src/store/poolStore.ts
+++ b/packages/ui-lending/src/store/poolStore.ts
@@ -1,0 +1,26 @@
+import { useState, useCallback } from 'react';
+import type { PoolData } from '../types';
+
+/**
+ * poolStore — shared state management for lending pools.
+ */
+export function usePoolStore() {
+  const [pools, setPools] = useState<PoolData[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const upsertPool = useCallback((pool: PoolData) => {
+    setPools(prev => [...prev.filter(p => p.id !== pool.id), pool]);
+  }, []);
+
+  const getPool = useCallback((id: string) =>
+    pools.find(p => p.id === id) ?? null, [pools]);
+
+  const getActivePools = useCallback(() =>
+    pools.filter(p => p.isActive), [pools]);
+
+  const getTotalTVL = useCallback(() =>
+    pools.reduce((sum, p) => sum + p.totalSupply, 0), [pools]);
+
+  return { pools, isLoading, error, upsertPool, getPool, getActivePools, getTotalTVL, setPools, setIsLoading, setError };
+}

--- a/packages/ui-lending/src/store/positionStore.ts
+++ b/packages/ui-lending/src/store/positionStore.ts
@@ -1,0 +1,32 @@
+import { useState, useCallback } from 'react';
+import type { Position } from '../types';
+
+/**
+ * positionStore — shared state management for all user positions.
+ * Lightweight store using React hooks — swap for Zustand/Redux if needed.
+ */
+export function usePositionStore() {
+  const [positions, setPositions] = useState<Position[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const addPosition = useCallback((position: Position) => {
+    setPositions(prev => [...prev.filter(p => p.id !== position.id), position]);
+  }, []);
+
+  const removePosition = useCallback((id: string) => {
+    setPositions(prev => prev.filter(p => p.id !== id));
+  }, []);
+
+  const updatePosition = useCallback((id: string, updates: Partial<Position>) => {
+    setPositions(prev => prev.map(p => p.id === id ? { ...p, ...updates } : p));
+  }, []);
+
+  const getTotalSupplied = useCallback(() =>
+    positions.reduce((sum, p) => sum + p.supplied * p.price, 0), [positions]);
+
+  const getTotalBorrowed = useCallback(() =>
+    positions.reduce((sum, p) => sum + p.borrowed * p.price, 0), [positions]);
+
+  return { positions, isLoading, error, addPosition, removePosition, updatePosition, getTotalSupplied, getTotalBorrowed, setIsLoading, setError };
+}

--- a/packages/ui-lending/src/types/index.ts
+++ b/packages/ui-lending/src/types/index.ts
@@ -1,0 +1,73 @@
+/**
+ * Core lending domain types for the @stellarlend/ui-lending package.
+ */
+
+export type Theme = 'light' | 'dark';
+
+export interface ThemeColors {
+  primary: string;
+  secondary: string;
+  success: string;
+  warning: string;
+  danger: string;
+  background: string;
+  surface: string;
+  text: string;
+  textMuted: string;
+  border: string;
+}
+
+export interface LendingTheme {
+  mode: Theme;
+  colors: ThemeColors;
+}
+
+export interface Position {
+  id: string;
+  asset: string;
+  symbol: string;
+  supplied: number;
+  borrowed: number;
+  supplyApy: number;
+  borrowApy: number;
+  collateralFactor: number;
+  price: number;
+}
+
+export interface PoolData {
+  id: string;
+  asset: string;
+  symbol: string;
+  totalSupply: number;
+  totalBorrow: number;
+  supplyApy: number;
+  borrowApy: number;
+  utilization: number;
+  collateralFactor: number;
+  liquidationThreshold: number;
+  price: number;
+  isActive: boolean;
+}
+
+export interface HealthFactor {
+  value: number;
+  status: 'safe' | 'warning' | 'danger' | 'liquidatable';
+  collateralValue: number;
+  borrowedValue: number;
+  liquidationThreshold: number;
+}
+
+export interface RatePoint {
+  timestamp: number;
+  supplyApy: number;
+  borrowApy: number;
+  utilization: number;
+}
+
+export interface LiquidationRisk {
+  healthFactor: number;
+  liquidationPrice: number;
+  currentPrice: number;
+  safetyBuffer: number;
+  riskLevel: 'low' | 'medium' | 'high' | 'critical';
+}

--- a/packages/ui-lending/src/utils/theme.ts
+++ b/packages/ui-lending/src/utils/theme.ts
@@ -1,0 +1,51 @@
+import type { LendingTheme, ThemeColors } from '../types';
+
+export const LIGHT_COLORS: ThemeColors = {
+  primary: '#2563eb',
+  secondary: '#7c3aed',
+  success: '#16a34a',
+  warning: '#d97706',
+  danger: '#dc2626',
+  background: '#f8fafc',
+  surface: '#ffffff',
+  text: '#0f172a',
+  textMuted: '#64748b',
+  border: '#e2e8f0',
+};
+
+export const DARK_COLORS: ThemeColors = {
+  primary: '#3b82f6',
+  secondary: '#8b5cf6',
+  success: '#22c55e',
+  warning: '#f59e0b',
+  danger: '#ef4444',
+  background: '#0f172a',
+  surface: '#1e293b',
+  text: '#f8fafc',
+  textMuted: '#94a3b8',
+  border: '#334155',
+};
+
+export function createTheme(mode: 'light' | 'dark' = 'light'): LendingTheme {
+  return {
+    mode,
+    colors: mode === 'dark' ? DARK_COLORS : LIGHT_COLORS,
+  };
+}
+
+export function getHealthColor(healthFactor: number, colors: ThemeColors): string {
+  if (healthFactor >= 2) return colors.success;
+  if (healthFactor >= 1.5) return colors.warning;
+  if (healthFactor >= 1) return colors.danger;
+  return colors.danger;
+}
+
+export function getRiskColor(riskLevel: string, colors: ThemeColors): string {
+  switch (riskLevel) {
+    case 'low': return colors.success;
+    case 'medium': return colors.warning;
+    case 'high': return colors.danger;
+    case 'critical': return colors.danger;
+    default: return colors.textMuted;
+  }
+}

--- a/packages/ui-lending/stories/PositionCard.stories.tsx
+++ b/packages/ui-lending/stories/PositionCard.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import { PositionCard } from '../src/components/PositionCard';
+import { createTheme } from '../src/utils/theme';
+
+const meta: Meta<typeof PositionCard> = {
+  title: 'Lending/PositionCard',
+  component: PositionCard,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof PositionCard>;
+
+const samplePosition = {
+  id: '1',
+  asset: 'USDC',
+  symbol: 'USDC',
+  supplied: 1000,
+  borrowed: 250,
+  supplyApy: 4.5,
+  borrowApy: 6.2,
+  collateralFactor: 0.8,
+  price: 1,
+};
+
+export const Default: Story = {
+  args: { position: samplePosition },
+};
+
+export const DarkMode: Story = {
+  args: { position: samplePosition, theme: createTheme('dark') },
+  parameters: { backgrounds: { default: 'dark' } },
+};
+
+export const Loading: Story = {
+  args: { position: samplePosition, isLoading: true },
+};
+
+export const WithActions: Story = {
+  args: {
+    position: samplePosition,
+    onSupply: (p) => alert(`Supply ${p.asset}`),
+    onBorrow: (p) => alert(`Borrow ${p.asset}`),
+    onRepay: (p) => alert(`Repay ${p.asset}`),
+    onWithdraw: (p) => alert(`Withdraw ${p.asset}`),
+  },
+};

--- a/packages/ui-lending/tsconfig.json
+++ b/packages/ui-lending/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
Closes #630 
## Description
Addresses issue #630 by decoupling and extracting duplicated lending components, custom hooks, and shared states from the primary frontend applications into a unified, isolated workspace package (`packages/ui-lending`). This establishes a single source of truth for our core lending UI, preventing feature and design drift.

## Proposed Changes
- **New Package Workspace**: Created `packages/ui-lending` containing decoupled component assets, theme configurations, and a build/bundling pipeline.
- **Component Core Extraction**: Ported `PositionCard`, `HealthMeter`, `RateChart`, `PoolCard`, and `LiquidationRiskGauge` into the shared ecosystem.
- **Data Hook Layer**: Centralized custom states into `usePosition`, `usePoolData`, `useHealthFactor`, and `useRates` hooks.
- **State Optimization**: Standardized the position and pool tracking mechanisms into modular, shared stores.
- **Edge-Case Support**: Baked uniform loading skeletons, data-empty placeholders, and localized fallback error layouts directly into the visual interface wrappers.
- **Documentation**: Configured Storybook workflows mapping the dark/light variations and numerical data variations for every extracted component.

## Verification Checklist
- [x] `@stellarlend/ui-lending` builds smoothly with no TypeScript or linting compilation errors.
- [x] Storybook runs natively local and correctly mirrors component variants (loading, empty, error states).
- [x] Dark and Light mode theme switching works flawlessly across all extracted items.
- [x] Mobile/Desktop responsive layouts verified in isolation.
- [x] Migrated views in the main application compile and render accurately without visual regressions.
