### PR TITLE
Formal verification for rate/liquidation math, historical rate analytics, and cross-protocol ETL

### DIFF
--- a/api/src/__tests__/analytics.service.test.ts
+++ b/api/src/__tests__/analytics.service.test.ts
@@ -1,0 +1,146 @@
+import {
+  getRateVolatility,
+  getWeightedAverageRates,
+  getRateChangeEvents,
+  getRateHistoryRange,
+} from '../services/analytics.service';
+import { StellarService } from '../services/stellar.service';
+import { redisCacheService } from '../services/redisCache.service';
+import { ValidationError } from '../utils/errors';
+
+describe('analytics.service — historical rate analytics', () => {
+  let getPoolRateAtSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    redisCacheService.clearAllForTests();
+    // Deterministic, monotonically increasing borrow APY per call so
+    // volatility/weighted-average/rate-change tests have real variance to
+    // observe (the default simulated implementation returns a constant
+    // rate per pool address, which would make every metric trivially zero).
+    let call = 0;
+    getPoolRateAtSpy = jest
+      .spyOn(StellarService.prototype, 'getPoolRateAt')
+      .mockImplementation(async () => {
+        call += 1;
+        const borrowApy = 0.05 + (call % 5) * 0.01;
+        return {
+          depositApy: borrowApy * 0.7,
+          borrowApy,
+          utilizationRate: 0.5,
+        };
+      });
+  });
+
+  afterEach(() => {
+    getPoolRateAtSpy.mockRestore();
+  });
+
+  describe('getRateVolatility', () => {
+    it('computes a rolling standard deviation with the requested window size', async () => {
+      const result = await getRateVolatility({ timeRange: '7d', poolAddress: 'pool_a' }, 5);
+      expect(result.length).toBeGreaterThan(0);
+      for (const point of result) {
+        expect(point.windowSize).toBe(5);
+        expect(point.borrowApyStdDev).toBeGreaterThanOrEqual(0);
+        expect(point.depositApyStdDev).toBeGreaterThanOrEqual(0);
+      }
+      // With varying rates, at least one window should show non-zero volatility.
+      expect(result.some((p) => p.borrowApyStdDev > 0)).toBe(true);
+    });
+
+    it('returns an empty array when there are fewer samples than the window size', async () => {
+      const result = await getRateVolatility({ timeRange: '7d', poolAddress: 'pool_b' }, 1000);
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('getWeightedAverageRates', () => {
+    it('buckets rate points by the requested granularity', async () => {
+      const result = await getWeightedAverageRates(
+        { timeRange: '30d', poolAddress: 'pool_c' },
+        'weekly'
+      );
+      expect(result.length).toBeGreaterThan(0);
+      for (const bucket of result) {
+        expect(bucket.granularity).toBe('weekly');
+        expect(bucket.sampleCount).toBeGreaterThan(0);
+        expect(new Date(bucket.periodStart).getTime()).toBeLessThan(
+          new Date(bucket.periodEnd).getTime()
+        );
+      }
+    });
+
+    it('sorts buckets chronologically', async () => {
+      const result = await getWeightedAverageRates(
+        { timeRange: '30d', poolAddress: 'pool_d' },
+        'daily'
+      );
+      const starts = result.map((b) => new Date(b.periodStart).getTime());
+      const sorted = [...starts].sort((a, b) => a - b);
+      expect(starts).toEqual(sorted);
+    });
+  });
+
+  describe('getRateChangeEvents', () => {
+    it('flags borrow-rate moves at or above the threshold', async () => {
+      const events = await getRateChangeEvents({ timeRange: '7d', poolAddress: 'pool_e' }, 10);
+      expect(events.length).toBeGreaterThan(0);
+      for (const event of events) {
+        expect(Math.abs(event.deltaBps)).toBeGreaterThanOrEqual(10);
+        expect(['increase', 'decrease']).toContain(event.changeType);
+        expect(event.governanceActionId).toBeUndefined();
+      }
+    });
+
+    it('finds no events when the threshold is set impossibly high', async () => {
+      const events = await getRateChangeEvents(
+        { timeRange: '7d', poolAddress: 'pool_f' },
+        1_000_000
+      );
+      expect(events).toEqual([]);
+    });
+  });
+
+  describe('getRateHistoryRange', () => {
+    it('returns daily-bucketed points across an explicit date range', async () => {
+      const from = '2024-01-01T00:00:00.000Z';
+      const to = '2024-01-05T00:00:00.000Z';
+      const result = await getRateHistoryRange({ asset: 'pool_g', from, to, granularity: 'daily' });
+      expect(result.length).toBe(5); // Jan 1..5 inclusive at daily granularity
+      expect(result[0]!.poolAddress).toBe('pool_g');
+    });
+
+    it('rejects a `from` after `to`', async () => {
+      await expect(
+        getRateHistoryRange({
+          asset: 'pool_h',
+          from: '2024-01-05T00:00:00.000Z',
+          to: '2024-01-01T00:00:00.000Z',
+        })
+      ).rejects.toThrow(ValidationError);
+    });
+
+    it('rejects an invalid date string', async () => {
+      await expect(
+        getRateHistoryRange({ asset: 'pool_i', from: 'not-a-date', to: '2024-01-01T00:00:00.000Z' })
+      ).rejects.toThrow(ValidationError);
+    });
+
+    it('rejects a range that would exceed the maximum bucket count', async () => {
+      await expect(
+        getRateHistoryRange({
+          asset: 'pool_j',
+          from: '2000-01-01T00:00:00.000Z',
+          to: '2024-01-01T00:00:00.000Z',
+          granularity: 'hourly',
+        })
+      ).rejects.toThrow(ValidationError);
+    });
+
+    it('defaults to the last 7 days at daily granularity when no range is given', async () => {
+      const result = await getRateHistoryRange({ asset: 'pool_k' });
+      expect(result.length).toBeGreaterThan(0);
+      expect(result.length).toBeLessThanOrEqual(8);
+    });
+  });
+});

--- a/api/src/__tests__/crossProtocolEtl.service.test.ts
+++ b/api/src/__tests__/crossProtocolEtl.service.test.ts
@@ -1,0 +1,165 @@
+import {
+  refreshCrossProtocolData,
+  getCrossProtocolComparison,
+  computeMarketShare,
+  getLeaderboard,
+} from '../services/cross-protocol-etl/etl.service';
+import { ProtocolAdapter, StandardizedProtocolMetrics } from '../services/cross-protocol-etl/types';
+import { redisCacheService } from '../services/redisCache.service';
+
+function metric(overrides: Partial<StandardizedProtocolMetrics> = {}): StandardizedProtocolMetrics {
+  return {
+    protocol: 'test-protocol',
+    displayName: 'Test Protocol',
+    chain: 'test-chain',
+    asset: 'USDC',
+    supplyApy: 0.03,
+    borrowApy: 0.05,
+    tvlUsd: 1_000_000,
+    utilizationRate: 0.6,
+    fetchedAt: new Date().toISOString(),
+    source: 'test',
+    ...overrides,
+  };
+}
+
+function fakeAdapter(protocolId: string, metrics: StandardizedProtocolMetrics[]): ProtocolAdapter {
+  return {
+    protocolId,
+    displayName: protocolId,
+    fetchMetrics: async () => metrics,
+  };
+}
+
+function failingAdapter(protocolId: string, error: Error): ProtocolAdapter {
+  return {
+    protocolId,
+    displayName: protocolId,
+    fetchMetrics: async () => {
+      throw error;
+    },
+  };
+}
+
+describe('cross-protocol-etl.service', () => {
+  beforeEach(() => {
+    redisCacheService.clearAllForTests();
+  });
+
+  describe('refreshCrossProtocolData', () => {
+    it('merges metrics from all adapters', async () => {
+      const adapters = [
+        fakeAdapter('a', [metric({ protocol: 'a', asset: 'USDC' })]),
+        fakeAdapter('b', [metric({ protocol: 'b', asset: 'USDT' })]),
+      ];
+      const result = await refreshCrossProtocolData(adapters);
+      expect(result.metrics).toHaveLength(2);
+      expect(result.failedSources).toEqual([]);
+      expect(result.metrics.map((m) => m.protocol).sort()).toEqual(['a', 'b']);
+    });
+
+    it('isolates a failing adapter without blocking the others', async () => {
+      const adapters = [
+        fakeAdapter('good', [metric({ protocol: 'good' })]),
+        failingAdapter('bad', new Error('upstream unreachable')),
+      ];
+      const result = await refreshCrossProtocolData(adapters);
+      expect(result.metrics).toHaveLength(1);
+      expect(result.metrics[0]!.protocol).toBe('good');
+      expect(result.failedSources).toEqual(['bad']);
+    });
+
+    it('filters out metrics that fail data quality checks', async () => {
+      const adapters = [
+        fakeAdapter('mixed', [
+          metric({ protocol: 'mixed', asset: 'GOOD' }),
+          metric({ protocol: 'mixed', asset: 'BAD_APY', supplyApy: 50 }), // 5000% APY — implausible
+          metric({ protocol: 'mixed', asset: 'BAD_UTIL', utilizationRate: 1.5 }),
+          metric({ protocol: 'mixed', asset: 'BAD_TVL', tvlUsd: -100 }),
+        ]),
+      ];
+      const result = await refreshCrossProtocolData(adapters);
+      expect(result.metrics).toHaveLength(1);
+      expect(result.metrics[0]!.asset).toBe('GOOD');
+      expect(result.qualityIssues).toHaveLength(3);
+      expect(result.qualityIssues.map((i) => i.asset).sort()).toEqual([
+        'BAD_APY',
+        'BAD_TVL',
+        'BAD_UTIL',
+      ]);
+    });
+  });
+
+  describe('getCrossProtocolComparison caching', () => {
+    it('caches the result so a second call does not re-invoke adapters', async () => {
+      let calls = 0;
+      const adapters = [
+        {
+          protocolId: 'counted',
+          displayName: 'counted',
+          fetchMetrics: async () => {
+            calls += 1;
+            return [metric({ protocol: 'counted' })];
+          },
+        },
+      ];
+      await getCrossProtocolComparison(adapters);
+      await getCrossProtocolComparison(adapters);
+      expect(calls).toBe(1);
+    });
+  });
+
+  describe('computeMarketShare', () => {
+    it('computes TVL-weighted share per protocol, sorted descending', () => {
+      const metrics = [
+        metric({ protocol: 'big', tvlUsd: 750 }),
+        metric({ protocol: 'small', tvlUsd: 250 }),
+      ];
+      const shares = computeMarketShare(metrics);
+      expect(shares).toEqual([
+        { protocol: 'big', tvlUsd: 750, marketSharePct: 75 },
+        { protocol: 'small', tvlUsd: 250, marketSharePct: 25 },
+      ]);
+    });
+
+    it('sums TVL across multiple pools of the same protocol', () => {
+      const metrics = [
+        metric({ protocol: 'multi', asset: 'USDC', tvlUsd: 400 }),
+        metric({ protocol: 'multi', asset: 'USDT', tvlUsd: 600 }),
+      ];
+      const shares = computeMarketShare(metrics);
+      expect(shares).toEqual([{ protocol: 'multi', tvlUsd: 1000, marketSharePct: 100 }]);
+    });
+
+    it('returns 0% shares (not NaN) when total TVL is zero', () => {
+      const shares = computeMarketShare([metric({ tvlUsd: 0 })]);
+      expect(shares[0]!.marketSharePct).toBe(0);
+    });
+  });
+
+  describe('getLeaderboard', () => {
+    it('ranks protocols by the requested metric, descending', async () => {
+      const adapters = [
+        fakeAdapter('x', [
+          metric({ protocol: 'low-apy', supplyApy: 0.01, tvlUsd: 100 }),
+          metric({ protocol: 'high-apy', supplyApy: 0.09, tvlUsd: 50 }),
+        ]),
+      ];
+      const board = await getLeaderboard('supplyApy', 10, adapters);
+      expect(board.map((e) => e.protocol)).toEqual(['high-apy', 'low-apy']);
+      expect(board[0]!.rank).toBe(1);
+      expect(board[0]!.metricValue).toBe(0.09);
+    });
+
+    it('respects the limit', async () => {
+      const adapters = [
+        fakeAdapter(
+          'many',
+          Array.from({ length: 5 }, (_, i) => metric({ protocol: `p${i}`, tvlUsd: i }))
+        ),
+      ];
+      const board = await getLeaderboard('tvlUsd', 2, adapters);
+      expect(board).toHaveLength(2);
+    });
+  });
+});

--- a/api/src/__tests__/defiLlamaAdapter.test.ts
+++ b/api/src/__tests__/defiLlamaAdapter.test.ts
@@ -1,0 +1,61 @@
+import axios from 'axios';
+import { DefiLlamaAdapter } from '../services/cross-protocol-etl/adapters/defiLlamaAdapter';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('DefiLlamaAdapter', () => {
+  it('normalizes tracked-project pools into StandardizedProtocolMetrics', async () => {
+    mockedAxios.get.mockResolvedValueOnce({
+      data: {
+        status: 'success',
+        data: [
+          { chain: 'Ethereum', project: 'aave-v3', symbol: 'USDC', tvlUsd: 500_000_000, apy: 3.2 },
+          {
+            chain: 'Ethereum',
+            project: 'compound-v3',
+            symbol: 'USDC',
+            tvlUsd: 200_000_000,
+            apy: 2.8,
+          },
+          // Untracked project must be filtered out.
+          { chain: 'Ethereum', project: 'some-random-farm', symbol: 'USDC', tvlUsd: 10, apy: 999 },
+        ],
+      },
+    });
+
+    const adapter = new DefiLlamaAdapter();
+    const metrics = await adapter.fetchMetrics();
+
+    expect(metrics).toHaveLength(2);
+    expect(metrics.map((m) => m.protocol).sort()).toEqual(['aave-v3', 'compound-v3']);
+
+    const aave = metrics.find((m) => m.protocol === 'aave-v3')!;
+    expect(aave.supplyApy).toBeCloseTo(0.032);
+    expect(aave.tvlUsd).toBe(500_000_000);
+    expect(aave.chain).toBe('Ethereum');
+    expect(aave.source).toBe('defillama');
+    // Honestly zeroed, not fabricated — see adapter doc comment.
+    expect(aave.borrowApy).toBe(0);
+    expect(aave.utilizationRate).toBe(0);
+  });
+
+  it('handles a null apy without throwing', async () => {
+    mockedAxios.get.mockResolvedValueOnce({
+      data: {
+        status: 'success',
+        data: [{ chain: 'Ethereum', project: 'spark', symbol: 'DAI', tvlUsd: 1000, apy: null }],
+      },
+    });
+
+    const adapter = new DefiLlamaAdapter();
+    const metrics = await adapter.fetchMetrics();
+    expect(metrics[0]!.supplyApy).toBe(0);
+  });
+
+  it('propagates upstream errors so the ETL orchestrator can isolate them', async () => {
+    mockedAxios.get.mockRejectedValueOnce(new Error('network error'));
+    const adapter = new DefiLlamaAdapter();
+    await expect(adapter.fetchMetrics()).rejects.toThrow('network error');
+  });
+});

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -21,6 +21,8 @@ import zkProofRoutes from './routes/zkProof.routes';
 import verificationRoutes from './routes/verification.routes';
 import configRoutes from './routes/config.routes';
 import analyticsRoutes from './routes/analytics.routes';
+import ratesRoutes from './routes/rates.routes';
+import crossProtocolRoutes from './routes/crossProtocol.routes';
 import developerRoutes from './routes/developer.routes';
 import mevRoutes from './routes/mev.routes';
 import reputationRoutes from './routes/reputation.routes';
@@ -35,10 +37,7 @@ import { errorHandler } from './middleware/errorHandler';
 import { idempotencyMiddleware } from './middleware/idempotency';
 import { resetSensitiveRateLimits, sensitiveOperationRateLimiter } from './middleware/rate-limit';
 import { swaggerSpec, versionListHandler, v1Spec } from './config/swagger';
-import {
-  versionMiddleware,
-  legacyCompatibilityMiddleware,
-} from './middleware/versioning';
+import { versionMiddleware, legacyCompatibilityMiddleware } from './middleware/versioning';
 import logger from './utils/logger';
 import { requestIdMiddleware } from './middleware/requestId';
 import { requestLogger } from './middleware/requestLogger';
@@ -198,6 +197,8 @@ app.use('/api/zk', legacySecurityCompat, zkProofRoutes);
 app.use('/api/verification', legacySecurityCompat, verificationRoutes);
 app.use('/api/config', legacySystemCompat, configRoutes);
 app.use('/api/analytics', legacySystemCompat, analyticsRoutes);
+app.use('/api/rates', legacySystemCompat, ratesRoutes);
+app.use('/api/cross-protocol', legacySystemCompat, crossProtocolRoutes);
 app.use('/api/mev', legacySecurityCompat, mevRoutes);
 app.use('/api/reputation', reputationRoutes);
 app.use('/api/social', socialRoutes);

--- a/api/src/controllers/analytics.controller.ts
+++ b/api/src/controllers/analytics.controller.ts
@@ -6,8 +6,11 @@ import {
   getProtocolRevenue,
   getAnalyticsSummary,
   exportAnalytics,
+  getRateVolatility,
+  getWeightedAverageRates,
+  getRateChangeEvents,
 } from '../services/analytics.service';
-import { AnalyticsQuery } from '../types/analytics';
+import { AnalyticsQuery, RateGranularity } from '../types/analytics';
 
 export const historicalRates = async (
   req: Request,
@@ -107,20 +110,71 @@ export const analyticsExport = async (
 
     if (format === 'csv') {
       res.setHeader('Content-Type', 'text/csv');
-      res.setHeader(
-        'Content-Disposition',
-        'attachment; filename="analytics-export.csv"'
-      );
+      res.setHeader('Content-Disposition', 'attachment; filename="analytics-export.csv"');
       res.status(200).send(data);
       return;
     }
 
     res.setHeader('Content-Type', 'application/json');
-    res.setHeader(
-      'Content-Disposition',
-      'attachment; filename="analytics-export.json"'
-    );
+    res.setHeader('Content-Disposition', 'attachment; filename="analytics-export.json"');
     res.status(200).json(data);
+  } catch (error) {
+    next(error);
+    return;
+  }
+};
+
+export const rateVolatility = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    const query: AnalyticsQuery = {
+      timeRange: (req.query.timeRange as AnalyticsQuery['timeRange']) || '7d',
+      poolAddress: req.query.poolAddress as string,
+    };
+    const windowSize = req.query.windowSize ? Number(req.query.windowSize) : undefined;
+    const volatility = await getRateVolatility(query, windowSize);
+    res.status(200).json(volatility);
+  } catch (error) {
+    next(error);
+    return;
+  }
+};
+
+export const weightedAverageRates = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    const query: AnalyticsQuery = {
+      timeRange: (req.query.timeRange as AnalyticsQuery['timeRange']) || '30d',
+      poolAddress: req.query.poolAddress as string,
+    };
+    const granularity = (req.query.granularity as RateGranularity) || 'daily';
+    const rates = await getWeightedAverageRates(query, granularity);
+    res.status(200).json(rates);
+  } catch (error) {
+    next(error);
+    return;
+  }
+};
+
+export const rateChangeEvents = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    const query: AnalyticsQuery = {
+      timeRange: (req.query.timeRange as AnalyticsQuery['timeRange']) || '7d',
+      poolAddress: req.query.poolAddress as string,
+    };
+    const thresholdBps = req.query.thresholdBps ? Number(req.query.thresholdBps) : undefined;
+    const events = await getRateChangeEvents(query, thresholdBps);
+    res.status(200).json(events);
   } catch (error) {
     next(error);
     return;

--- a/api/src/controllers/crossProtocol.controller.ts
+++ b/api/src/controllers/crossProtocol.controller.ts
@@ -1,0 +1,55 @@
+import { Request, Response, NextFunction } from 'express';
+import {
+  getCrossProtocolComparison,
+  getMarketShare,
+  getLeaderboard,
+} from '../services/cross-protocol-etl/etl.service';
+import { LeaderboardMetric } from '../services/cross-protocol-etl/types';
+import { ValidationError } from '../utils/errors';
+
+const VALID_LEADERBOARD_METRICS: LeaderboardMetric[] = ['supplyApy', 'borrowApy', 'tvlUsd'];
+
+export const compare = async (_req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const result = await getCrossProtocolComparison();
+    res.status(200).json(result);
+  } catch (error) {
+    next(error);
+    return;
+  }
+};
+
+export const marketShare = async (
+  _req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    const shares = await getMarketShare();
+    res.status(200).json(shares);
+  } catch (error) {
+    next(error);
+    return;
+  }
+};
+
+export const leaderboard = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    const metricParam = (req.query.metric as string) || 'tvlUsd';
+    if (!VALID_LEADERBOARD_METRICS.includes(metricParam as LeaderboardMetric)) {
+      throw new ValidationError(
+        `Invalid metric "${metricParam}". Must be one of: ${VALID_LEADERBOARD_METRICS.join(', ')}`
+      );
+    }
+    const limit = req.query.limit ? Number(req.query.limit) : undefined;
+    const entries = await getLeaderboard(metricParam as LeaderboardMetric, limit);
+    res.status(200).json(entries);
+  } catch (error) {
+    next(error);
+    return;
+  }
+};

--- a/api/src/controllers/rates.controller.ts
+++ b/api/src/controllers/rates.controller.ts
@@ -1,0 +1,23 @@
+import { Request, Response, NextFunction } from 'express';
+import { getRateHistoryRange } from '../services/analytics.service';
+import { RateGranularity, RateHistoryQuery } from '../types/analytics';
+
+export const rateHistory = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    const query: RateHistoryQuery = {
+      asset: req.query.asset as string,
+      from: req.query.from as string,
+      to: req.query.to as string,
+      granularity: req.query.granularity as RateGranularity,
+    };
+    const history = await getRateHistoryRange(query);
+    res.status(200).json(history);
+  } catch (error) {
+    next(error);
+    return;
+  }
+};

--- a/api/src/routes/analytics.routes.ts
+++ b/api/src/routes/analytics.routes.ts
@@ -106,4 +106,83 @@ router.get('/summary', analyticsController.analyticsSummary);
  */
 router.get('/export', analyticsController.analyticsExport);
 
+/**
+ * @openapi
+ * /analytics/rate-volatility:
+ *   get:
+ *     summary: Rolling standard deviation of deposit/borrow APY
+ *     tags:
+ *       - Analytics
+ *     parameters:
+ *       - in: query
+ *         name: timeRange
+ *         schema:
+ *           type: string
+ *           enum: [1d, 7d, 30d, 1y]
+ *           default: 7d
+ *       - in: query
+ *         name: poolAddress
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: windowSize
+ *         schema:
+ *           type: integer
+ *           default: 10
+ */
+router.get('/rate-volatility', analyticsController.rateVolatility);
+
+/**
+ * @openapi
+ * /analytics/weighted-average-rates:
+ *   get:
+ *     summary: Weighted average APY bucketed by day/week/month
+ *     tags:
+ *       - Analytics
+ *     parameters:
+ *       - in: query
+ *         name: timeRange
+ *         schema:
+ *           type: string
+ *           enum: [1d, 7d, 30d, 1y]
+ *           default: 30d
+ *       - in: query
+ *         name: poolAddress
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: granularity
+ *         schema:
+ *           type: string
+ *           enum: [hourly, daily, weekly, monthly]
+ *           default: daily
+ */
+router.get('/weighted-average-rates', analyticsController.weightedAverageRates);
+
+/**
+ * @openapi
+ * /analytics/rate-change-events:
+ *   get:
+ *     summary: Detected material borrow-rate change events
+ *     tags:
+ *       - Analytics
+ *     parameters:
+ *       - in: query
+ *         name: timeRange
+ *         schema:
+ *           type: string
+ *           enum: [1d, 7d, 30d, 1y]
+ *           default: 7d
+ *       - in: query
+ *         name: poolAddress
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: thresholdBps
+ *         schema:
+ *           type: integer
+ *           default: 10
+ */
+router.get('/rate-change-events', analyticsController.rateChangeEvents);
+
 export default router;

--- a/api/src/routes/crossProtocol.routes.ts
+++ b/api/src/routes/crossProtocol.routes.ts
@@ -1,0 +1,48 @@
+import { Router } from 'express';
+import * as crossProtocolController from '../controllers/crossProtocol.controller';
+
+const router: Router = Router();
+
+/**
+ * @openapi
+ * /cross-protocol/compare:
+ *   get:
+ *     summary: Side-by-side metrics comparison across StellarLend and tracked peer protocols
+ *     tags:
+ *       - Cross-Protocol
+ */
+router.get('/compare', crossProtocolController.compare);
+
+/**
+ * @openapi
+ * /cross-protocol/market-share:
+ *   get:
+ *     summary: TVL-weighted market share per protocol
+ *     tags:
+ *       - Cross-Protocol
+ */
+router.get('/market-share', crossProtocolController.marketShare);
+
+/**
+ * @openapi
+ * /cross-protocol/leaderboard:
+ *   get:
+ *     summary: Protocol ranking by a chosen metric
+ *     tags:
+ *       - Cross-Protocol
+ *     parameters:
+ *       - in: query
+ *         name: metric
+ *         schema:
+ *           type: string
+ *           enum: [supplyApy, borrowApy, tvlUsd]
+ *           default: tvlUsd
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           default: 20
+ */
+router.get('/leaderboard', crossProtocolController.leaderboard);
+
+export default router;

--- a/api/src/routes/rates.routes.ts
+++ b/api/src/routes/rates.routes.ts
@@ -1,0 +1,40 @@
+import { Router } from 'express';
+import * as ratesController from '../controllers/rates.controller';
+
+const router: Router = Router();
+
+/**
+ * @openapi
+ * /rates/history:
+ *   get:
+ *     summary: Historical interest rates for an asset over an explicit date range
+ *     description: >
+ *       Returns deposit/borrow APY snapshots for `asset` between `from` and
+ *       `to`, bucketed at `granularity`. Range is capped to 1000 buckets.
+ *     tags:
+ *       - Rates
+ *     parameters:
+ *       - in: query
+ *         name: asset
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: from
+ *         schema:
+ *           type: string
+ *           format: date-time
+ *       - in: query
+ *         name: to
+ *         schema:
+ *           type: string
+ *           format: date-time
+ *       - in: query
+ *         name: granularity
+ *         schema:
+ *           type: string
+ *           enum: [hourly, daily, weekly, monthly]
+ *           default: daily
+ */
+router.get('/history', ratesController.rateHistory);
+
+export default router;

--- a/api/src/services/analytics.service.ts
+++ b/api/src/services/analytics.service.ts
@@ -6,12 +6,35 @@ import {
   AnalyticsSummary,
   AnalyticsQuery,
   AnalyticsExportData,
+  RateVolatilityPoint,
+  WeightedAverageRatePoint,
+  RateChangeEvent,
+  RateHistoryQuery,
+  RateGranularity,
 } from '../types/analytics';
 import { StellarService } from './stellar.service';
 import { redisCacheService } from './redisCache.service';
 import { config } from '../config';
+import { ValidationError } from '../utils/errors';
 
 const ANALYTICS_CACHE_TTL_S = 60;
+const DEFAULT_VOLATILITY_WINDOW = 10;
+const DEFAULT_RATE_CHANGE_THRESHOLD_BPS = 10;
+const MAX_RATE_HISTORY_BUCKETS = 1000;
+
+const GRANULARITY_MS: Record<RateGranularity, number> = {
+  hourly: 3_600_000,
+  daily: 86_400_000,
+  weekly: 604_800_000,
+  monthly: 2_592_000_000,
+};
+
+function standardDeviation(values: number[]): number {
+  if (values.length === 0) return 0;
+  const mean = values.reduce((sum, v) => sum + v, 0) / values.length;
+  const variance = values.reduce((sum, v) => sum + (v - mean) ** 2, 0) / values.length;
+  return Math.sqrt(variance);
+}
 
 function generateTimePoints(timeRange: string, count: number): number[] {
   const now = Date.now();
@@ -26,9 +49,7 @@ function generateTimePoints(timeRange: string, count: number): number[] {
   return Array.from({ length: count }, (_, i) => now - range + interval * i);
 }
 
-export async function getHistoricalRates(
-  query: AnalyticsQuery
-): Promise<HistoricalRatePoint[]> {
+export async function getHistoricalRates(query: AnalyticsQuery): Promise<HistoricalRatePoint[]> {
   const cacheKey = redisCacheService.buildKey(
     'protocol',
     `historical-rates:${query.timeRange}:${query.poolAddress || 'all'}`
@@ -60,9 +81,7 @@ export async function getHistoricalRates(
   return rates;
 }
 
-export async function getPoolUtilization(
-  query: AnalyticsQuery
-): Promise<PoolUtilizationPoint[]> {
+export async function getPoolUtilization(query: AnalyticsQuery): Promise<PoolUtilizationPoint[]> {
   const cacheKey = redisCacheService.buildKey(
     'pool',
     `utilization:${query.timeRange}:${query.poolAddress || 'all'}`
@@ -115,13 +134,8 @@ export async function getRateComparison(): Promise<RateComparison[]> {
   return comparisons;
 }
 
-export async function getProtocolRevenue(
-  query: AnalyticsQuery
-): Promise<ProtocolRevenuePoint[]> {
-  const cacheKey = redisCacheService.buildKey(
-    'protocol',
-    `revenue:${query.timeRange}`
-  );
+export async function getProtocolRevenue(query: AnalyticsQuery): Promise<ProtocolRevenuePoint[]> {
+  const cacheKey = redisCacheService.buildKey('protocol', `revenue:${query.timeRange}`);
 
   const cached = await redisCacheService.get<ProtocolRevenuePoint[]>(cacheKey);
   if (cached) return cached;
@@ -131,9 +145,7 @@ export async function getProtocolRevenue(
 
   const revenue: ProtocolRevenuePoint[] = await Promise.all(
     timePoints.map(async (timestamp) => {
-      const revData = await stellarService.getProtocolRevenueAt(
-        Math.floor(timestamp / 1000)
-      );
+      const revData = await stellarService.getProtocolRevenueAt(Math.floor(timestamp / 1000));
       return {
         timestamp: new Date(timestamp).toISOString(),
         cumulativeRevenue: revData.cumulativeRevenue,
@@ -159,17 +171,11 @@ export async function getAnalyticsSummary(): Promise<AnalyticsSummary> {
   ]);
 
   const avgDepositApy =
-    pools.length > 0
-      ? pools.reduce((sum, p) => sum + p.depositApy, 0) / pools.length
-      : 0;
+    pools.length > 0 ? pools.reduce((sum, p) => sum + p.depositApy, 0) / pools.length : 0;
   const avgBorrowApy =
-    pools.length > 0
-      ? pools.reduce((sum, p) => sum + p.borrowApy, 0) / pools.length
-      : 0;
+    pools.length > 0 ? pools.reduce((sum, p) => sum + p.borrowApy, 0) / pools.length : 0;
   const avgUtilization =
-    pools.length > 0
-      ? pools.reduce((sum, p) => sum + p.utilizationRate, 0) / pools.length
-      : 0;
+    pools.length > 0 ? pools.reduce((sum, p) => sum + p.utilizationRate, 0) / pools.length : 0;
 
   const summary: AnalyticsSummary = {
     totalPools: pools.length,
@@ -190,14 +196,13 @@ export async function exportAnalytics(
   query: AnalyticsQuery,
   format: 'csv' | 'json'
 ): Promise<AnalyticsExportData | string> {
-  const [historicalRates, poolUtilization, rateComparison, revenue, summary] =
-    await Promise.all([
-      getHistoricalRates(query),
-      getPoolUtilization(query),
-      getRateComparison(),
-      getProtocolRevenue(query),
-      getAnalyticsSummary(),
-    ]);
+  const [historicalRates, poolUtilization, rateComparison, revenue, summary] = await Promise.all([
+    getHistoricalRates(query),
+    getPoolUtilization(query),
+    getRateComparison(),
+    getProtocolRevenue(query),
+    getAnalyticsSummary(),
+  ]);
 
   const data: AnalyticsExportData = {
     exportedAt: new Date().toISOString(),
@@ -217,14 +222,195 @@ export async function exportAnalytics(
 }
 
 function toAnalyticsCSV(data: AnalyticsExportData): string {
-  const header =
-    'timestamp,depositApy,borrowApy,utilizationRate,poolAddress,cumulativeRevenue';
+  const header = 'timestamp,depositApy,borrowApy,utilizationRate,poolAddress,cumulativeRevenue';
   const rows = data.historicalRates.map(
     (r) =>
       `${r.timestamp},${r.depositApy},${r.borrowApy},${r.utilizationRate},${r.poolAddress || ''},`
   );
-  const revenueRows = data.revenue.map(
-    (r) => `${r.timestamp},,,,,"${r.cumulativeRevenue}"`
-  );
+  const revenueRows = data.revenue.map((r) => `${r.timestamp},,,,,"${r.cumulativeRevenue}"`);
   return [header, ...rows, ...revenueRows].join('\n');
+}
+
+/**
+ * Rate volatility: rolling standard deviation of deposit/borrow APY over a
+ * fixed-size sliding window of historical rate snapshots.
+ */
+export async function getRateVolatility(
+  query: AnalyticsQuery,
+  windowSize: number = DEFAULT_VOLATILITY_WINDOW
+): Promise<RateVolatilityPoint[]> {
+  const cacheKey = redisCacheService.buildKey(
+    'protocol',
+    `rate-volatility:${query.timeRange}:${query.poolAddress || 'all'}:${windowSize}`
+  );
+  const cached = await redisCacheService.get<RateVolatilityPoint[]>(cacheKey);
+  if (cached) return cached;
+
+  const rates = await getHistoricalRates(query);
+  const volatility: RateVolatilityPoint[] = [];
+  for (let i = windowSize - 1; i < rates.length; i++) {
+    const window = rates.slice(i - windowSize + 1, i + 1);
+    volatility.push({
+      timestamp: rates[i]!.timestamp,
+      depositApyStdDev: standardDeviation(window.map((r) => r.depositApy)),
+      borrowApyStdDev: standardDeviation(window.map((r) => r.borrowApy)),
+      windowSize,
+      poolAddress: query.poolAddress,
+    });
+  }
+
+  await redisCacheService.set(cacheKey, volatility, ANALYTICS_CACHE_TTL_S);
+  return volatility;
+}
+
+/**
+ * Weighted average deposit/borrow APY bucketed by day/week/month.
+ *
+ * Historical rate snapshots are evenly spaced in time (see
+ * `generateTimePoints`), so the time-weighted average within a bucket
+ * reduces to the arithmetic mean of the samples that fall in it.
+ */
+export async function getWeightedAverageRates(
+  query: AnalyticsQuery,
+  granularity: RateGranularity = 'daily'
+): Promise<WeightedAverageRatePoint[]> {
+  const cacheKey = redisCacheService.buildKey(
+    'protocol',
+    `rate-weighted-avg:${query.timeRange}:${query.poolAddress || 'all'}:${granularity}`
+  );
+  const cached = await redisCacheService.get<WeightedAverageRatePoint[]>(cacheKey);
+  if (cached) return cached;
+
+  const rates = await getHistoricalRates(query);
+  const bucketMs = GRANULARITY_MS[granularity];
+  const buckets = new Map<number, HistoricalRatePoint[]>();
+
+  for (const point of rates) {
+    const bucketStart = Math.floor(new Date(point.timestamp).getTime() / bucketMs) * bucketMs;
+    const bucket = buckets.get(bucketStart);
+    if (bucket) {
+      bucket.push(point);
+    } else {
+      buckets.set(bucketStart, [point]);
+    }
+  }
+
+  const result: WeightedAverageRatePoint[] = Array.from(buckets.entries())
+    .sort(([a], [b]) => a - b)
+    .map(([bucketStart, points]) => {
+      const n = points.length;
+      return {
+        periodStart: new Date(bucketStart).toISOString(),
+        periodEnd: new Date(bucketStart + bucketMs).toISOString(),
+        granularity,
+        weightedAvgDepositApy: points.reduce((s, p) => s + p.depositApy, 0) / n,
+        weightedAvgBorrowApy: points.reduce((s, p) => s + p.borrowApy, 0) / n,
+        sampleCount: n,
+        poolAddress: query.poolAddress,
+      };
+    });
+
+  await redisCacheService.set(cacheKey, result, ANALYTICS_CACHE_TTL_S);
+  return result;
+}
+
+/**
+ * Detects material borrow-rate changes between consecutive historical rate
+ * snapshots (>= `thresholdBps` move). Each event carries an optional
+ * `governanceActionId` for traceability back to the parameter change that
+ * caused it; this simulated analytics layer (see `StellarService`'s
+ * `getPoolRateAt`) has no live governance-event feed to correlate against,
+ * so the field is left `undefined` here rather than fabricated.
+ */
+export async function getRateChangeEvents(
+  query: AnalyticsQuery,
+  thresholdBps: number = DEFAULT_RATE_CHANGE_THRESHOLD_BPS
+): Promise<RateChangeEvent[]> {
+  const cacheKey = redisCacheService.buildKey(
+    'protocol',
+    `rate-change-events:${query.timeRange}:${query.poolAddress || 'all'}:${thresholdBps}`
+  );
+  const cached = await redisCacheService.get<RateChangeEvent[]>(cacheKey);
+  if (cached) return cached;
+
+  const rates = await getHistoricalRates(query);
+  const events: RateChangeEvent[] = [];
+
+  for (let i = 1; i < rates.length; i++) {
+    const previous = rates[i - 1]!.borrowApy;
+    const current = rates[i]!.borrowApy;
+    const deltaBps = Math.round((current - previous) * 10_000);
+    if (Math.abs(deltaBps) >= thresholdBps) {
+      events.push({
+        timestamp: rates[i]!.timestamp,
+        poolAddress: query.poolAddress,
+        previousBorrowApy: previous,
+        newBorrowApy: current,
+        deltaBps,
+        changeType: deltaBps > 0 ? 'increase' : 'decrease',
+      });
+    }
+  }
+
+  await redisCacheService.set(cacheKey, events, ANALYTICS_CACHE_TTL_S);
+  return events;
+}
+
+/**
+ * `GET /api/rates/history?asset=&from=&to=&granularity=` — historical rate
+ * points over an explicit date range at a given granularity, rather than
+ * the preset `timeRange` buckets `getHistoricalRates` uses.
+ */
+export async function getRateHistoryRange(query: RateHistoryQuery): Promise<HistoricalRatePoint[]> {
+  const granularity = query.granularity ?? 'daily';
+  const to = query.to ? Date.parse(query.to) : Date.now();
+  const from = query.from ? Date.parse(query.from) : to - GRANULARITY_MS.daily * 7;
+
+  if (Number.isNaN(from) || Number.isNaN(to)) {
+    throw new ValidationError('Invalid `from`/`to` date for rate history query');
+  }
+  if (from > to) {
+    throw new ValidationError('`from` must not be after `to`');
+  }
+
+  const bucketMs = GRANULARITY_MS[granularity];
+  const bucketCount = Math.floor((to - from) / bucketMs) + 1;
+  if (bucketCount > MAX_RATE_HISTORY_BUCKETS) {
+    throw new ValidationError(
+      `Requested range produces ${bucketCount} buckets, exceeding the maximum of ${MAX_RATE_HISTORY_BUCKETS}. Widen the granularity or narrow the range.`
+    );
+  }
+
+  const cacheKey = redisCacheService.buildKey(
+    'protocol',
+    `rate-history-range:${query.asset || 'all'}:${from}:${to}:${granularity}`
+  );
+  const cached = await redisCacheService.get<HistoricalRatePoint[]>(cacheKey);
+  if (cached) return cached;
+
+  const stellarService = new StellarService();
+  const timestamps: number[] = [];
+  for (let t = from; t <= to; t += bucketMs) {
+    timestamps.push(t);
+  }
+  if (timestamps.length === 0) timestamps.push(from);
+
+  const rates: HistoricalRatePoint[] = await Promise.all(
+    timestamps.map(async (timestamp) => {
+      const rateData = await stellarService.getPoolRateAt(
+        query.asset || '',
+        Math.floor(timestamp / 1000)
+      );
+      return {
+        timestamp: new Date(timestamp).toISOString(),
+        depositApy: rateData.depositApy,
+        borrowApy: rateData.borrowApy,
+        utilizationRate: rateData.utilizationRate,
+        poolAddress: query.asset,
+      };
+    })
+  );
+
+  await redisCacheService.set(cacheKey, rates, ANALYTICS_CACHE_TTL_S);
+  return rates;
 }

--- a/api/src/services/cross-protocol-etl/adapters/defiLlamaAdapter.ts
+++ b/api/src/services/cross-protocol-etl/adapters/defiLlamaAdapter.ts
@@ -1,0 +1,69 @@
+import axios from 'axios';
+import { ProtocolAdapter, StandardizedProtocolMetrics } from '../types';
+
+const DEFAULT_DEFILLAMA_YIELDS_URL = 'https://yields.llama.fi/pools';
+
+interface DefiLlamaPool {
+  chain: string;
+  project: string;
+  symbol: string;
+  tvlUsd: number;
+  apy: number | null;
+}
+
+interface DefiLlamaPoolsResponse {
+  status: string;
+  data: DefiLlamaPool[];
+}
+
+/** DefiLlama `project` slugs this adapter tracks, mapped to a display name. */
+const TRACKED_PROJECTS: Record<string, string> = {
+  'aave-v3': 'Aave V3',
+  'compound-v3': 'Compound V3',
+  'morpho-blue': 'Morpho Blue',
+  spark: 'Spark',
+};
+
+/**
+ * Ingests peer-protocol lending metrics from DefiLlama's public yields API
+ * (`GET /pools`, no API key required — see
+ * https://defillama.com/docs/api). Filtered to `TRACKED_PROJECTS`
+ * (Aave, Compound, Morpho, Spark) per the cross-protocol comparison scope.
+ *
+ * The public `/pools` endpoint only reports supply-side APY and TVL — it
+ * does not expose per-pool borrow APY or utilization. Rather than fabricate
+ * those fields, this adapter honestly reports `borrowApy: 0` and
+ * `utilizationRate: 0` for DefiLlama-sourced rows; a future iteration could
+ * layer in a borrow-APY-capable source (e.g. each protocol's own subgraph)
+ * behind the same `ProtocolAdapter` interface without touching callers.
+ */
+export class DefiLlamaAdapter implements ProtocolAdapter {
+  readonly protocolId = 'defillama';
+  readonly displayName = 'DefiLlama-tracked peer protocols';
+
+  constructor(private readonly baseUrl: string = DEFAULT_DEFILLAMA_YIELDS_URL) {}
+
+  async fetchMetrics(): Promise<StandardizedProtocolMetrics[]> {
+    const response = await axios.get<DefiLlamaPoolsResponse>(this.baseUrl, {
+      timeout: 10_000,
+    });
+
+    const pools = response.data?.data ?? [];
+    const fetchedAt = new Date().toISOString();
+
+    return pools
+      .filter((pool) => pool.project in TRACKED_PROJECTS)
+      .map((pool) => ({
+        protocol: pool.project,
+        displayName: TRACKED_PROJECTS[pool.project]!,
+        chain: pool.chain,
+        asset: pool.symbol,
+        supplyApy: (pool.apy ?? 0) / 100,
+        borrowApy: 0,
+        tvlUsd: pool.tvlUsd ?? 0,
+        utilizationRate: 0,
+        fetchedAt,
+        source: 'defillama',
+      }));
+  }
+}

--- a/api/src/services/cross-protocol-etl/adapters/stellarLendAdapter.ts
+++ b/api/src/services/cross-protocol-etl/adapters/stellarLendAdapter.ts
@@ -1,0 +1,35 @@
+import { ProtocolAdapter, StandardizedProtocolMetrics } from '../types';
+import { getRateComparison } from '../../analytics.service';
+
+/**
+ * Wraps StellarLend's own pool metrics as a `ProtocolAdapter` so it can be
+ * compared against peer protocols through the same pipeline. Reuses
+ * `getRateComparison` (the existing simulated pool-metrics source) rather
+ * than duplicating pool-reading logic.
+ */
+export class StellarLendAdapter implements ProtocolAdapter {
+  readonly protocolId = 'stellarlend';
+  readonly displayName = 'StellarLend';
+
+  async fetchMetrics(): Promise<StandardizedProtocolMetrics[]> {
+    const pools = await getRateComparison();
+    const fetchedAt = new Date().toISOString();
+
+    return pools.map((pool) => ({
+      protocol: this.protocolId,
+      displayName: this.displayName,
+      chain: 'stellar',
+      asset: pool.poolName ?? pool.poolAddress,
+      supplyApy: pool.depositApy,
+      borrowApy: pool.borrowApy,
+      // `tvl` is already treated as a USD-equivalent notional value
+      // elsewhere in this analytics layer (see `getAnalyticsSummary`'s
+      // `totalValueLocked`), so this reuses the same convention rather
+      // than introducing a new one.
+      tvlUsd: Number(pool.tvl) || 0,
+      utilizationRate: pool.utilizationRate,
+      fetchedAt,
+      source: 'stellarlend-internal',
+    }));
+  }
+}

--- a/api/src/services/cross-protocol-etl/etl.service.ts
+++ b/api/src/services/cross-protocol-etl/etl.service.ts
@@ -1,0 +1,156 @@
+import {
+  StandardizedProtocolMetrics,
+  ProtocolAdapter,
+  DataQualityIssue,
+  CrossProtocolComparisonResult,
+  ProtocolMarketShare,
+  LeaderboardEntry,
+  LeaderboardMetric,
+} from './types';
+import { StellarLendAdapter } from './adapters/stellarLendAdapter';
+import { DefiLlamaAdapter } from './adapters/defiLlamaAdapter';
+import { redisCacheService } from '../redisCache.service';
+import logger from '../../utils/logger';
+
+// Data refreshes on-demand behind a cache TTL rather than a standalone cron
+// process (no job-scheduling infra exists elsewhere in this API service to
+// hook into); callers wanting a literal daily refresh cadence can invoke
+// `refreshCrossProtocolData` directly from an external scheduler.
+const ETL_CACHE_TTL_S = 300;
+
+const DEFAULT_ADAPTERS: ProtocolAdapter[] = [new StellarLendAdapter(), new DefiLlamaAdapter()];
+
+// Sanity bounds for the data-quality gate: an APY outside [0, 500%] or a
+// utilization outside [0, 1] indicates a malformed/corrupted upstream
+// record rather than a real market condition, and is excluded from
+// comparison output rather than silently skewing it.
+const MAX_PLAUSIBLE_APY = 5;
+
+function runDataQualityChecks(metrics: StandardizedProtocolMetrics[]): {
+  clean: StandardizedProtocolMetrics[];
+  issues: DataQualityIssue[];
+} {
+  const clean: StandardizedProtocolMetrics[] = [];
+  const issues: DataQualityIssue[] = [];
+
+  for (const metric of metrics) {
+    const reasons: string[] = [];
+    if (metric.supplyApy < 0 || metric.supplyApy > MAX_PLAUSIBLE_APY) {
+      reasons.push(
+        `supplyApy ${metric.supplyApy} outside plausible range [0, ${MAX_PLAUSIBLE_APY}]`
+      );
+    }
+    if (metric.borrowApy < 0 || metric.borrowApy > MAX_PLAUSIBLE_APY) {
+      reasons.push(
+        `borrowApy ${metric.borrowApy} outside plausible range [0, ${MAX_PLAUSIBLE_APY}]`
+      );
+    }
+    if (metric.tvlUsd < 0) {
+      reasons.push(`negative tvlUsd ${metric.tvlUsd}`);
+    }
+    if (metric.utilizationRate < 0 || metric.utilizationRate > 1) {
+      reasons.push(`utilizationRate ${metric.utilizationRate} outside [0, 1]`);
+    }
+
+    if (reasons.length > 0) {
+      issues.push({ protocol: metric.protocol, asset: metric.asset, reason: reasons.join('; ') });
+    } else {
+      clean.push(metric);
+    }
+  }
+
+  return { clean, issues };
+}
+
+/**
+ * Runs every adapter, isolating failures so one broken/unreachable source
+ * never blocks metrics from the rest, then applies the data-quality gate.
+ */
+export async function refreshCrossProtocolData(
+  adapters: ProtocolAdapter[] = DEFAULT_ADAPTERS
+): Promise<CrossProtocolComparisonResult> {
+  const settled = await Promise.allSettled(adapters.map((adapter) => adapter.fetchMetrics()));
+
+  const rawMetrics: StandardizedProtocolMetrics[] = [];
+  const failedSources: string[] = [];
+
+  settled.forEach((result, index) => {
+    const adapter = adapters[index]!;
+    if (result.status === 'fulfilled') {
+      rawMetrics.push(...result.value);
+    } else {
+      failedSources.push(adapter.protocolId);
+      logger.warn('Cross-protocol ETL adapter failed', {
+        protocolId: adapter.protocolId,
+        error: result.reason instanceof Error ? result.reason.message : result.reason,
+      });
+    }
+  });
+
+  const { clean, issues } = runDataQualityChecks(rawMetrics);
+
+  return {
+    metrics: clean,
+    qualityIssues: issues,
+    failedSources,
+    refreshedAt: new Date().toISOString(),
+  };
+}
+
+export async function getCrossProtocolComparison(
+  adapters?: ProtocolAdapter[]
+): Promise<CrossProtocolComparisonResult> {
+  const cacheKey = redisCacheService.buildKey('protocol', 'cross-protocol-comparison');
+  const cached = await redisCacheService.get<CrossProtocolComparisonResult>(cacheKey);
+  if (cached) return cached;
+
+  const result = await refreshCrossProtocolData(adapters);
+  await redisCacheService.set(cacheKey, result, ETL_CACHE_TTL_S);
+  return result;
+}
+
+/** TVL-weighted market share per protocol, sorted descending by TVL. */
+export function computeMarketShare(metrics: StandardizedProtocolMetrics[]): ProtocolMarketShare[] {
+  const totalsByProtocol = new Map<string, number>();
+  for (const metric of metrics) {
+    totalsByProtocol.set(
+      metric.protocol,
+      (totalsByProtocol.get(metric.protocol) ?? 0) + metric.tvlUsd
+    );
+  }
+
+  const grandTotal = Array.from(totalsByProtocol.values()).reduce((sum, v) => sum + v, 0);
+
+  return Array.from(totalsByProtocol.entries())
+    .map(([protocol, tvlUsd]) => ({
+      protocol,
+      tvlUsd,
+      marketSharePct: grandTotal > 0 ? (tvlUsd / grandTotal) * 100 : 0,
+    }))
+    .sort((a, b) => b.tvlUsd - a.tvlUsd);
+}
+
+export async function getMarketShare(adapters?: ProtocolAdapter[]): Promise<ProtocolMarketShare[]> {
+  const { metrics } = await getCrossProtocolComparison(adapters);
+  return computeMarketShare(metrics);
+}
+
+export async function getLeaderboard(
+  metric: LeaderboardMetric = 'tvlUsd',
+  limit = 20,
+  adapters?: ProtocolAdapter[]
+): Promise<LeaderboardEntry[]> {
+  const { metrics } = await getCrossProtocolComparison(adapters);
+
+  return [...metrics]
+    .sort((a, b) => b[metric] - a[metric])
+    .slice(0, limit)
+    .map((m, index) => ({
+      rank: index + 1,
+      protocol: m.protocol,
+      asset: m.asset,
+      metric,
+      metricValue: m[metric],
+      tvlUsd: m.tvlUsd,
+    }));
+}

--- a/api/src/services/cross-protocol-etl/types.ts
+++ b/api/src/services/cross-protocol-etl/types.ts
@@ -1,0 +1,65 @@
+/**
+ * Standardized schema every protocol adapter normalizes into, so metrics
+ * from different sources (StellarLend's own pools, DefiLlama-tracked peer
+ * protocols, ...) can be compared apples-to-apples.
+ */
+export interface StandardizedProtocolMetrics {
+  /** Stable machine-readable identifier, e.g. 'aave-v3', 'stellarlend'. */
+  protocol: string;
+  displayName: string;
+  chain: string;
+  /** Asset symbol, e.g. 'USDC'. */
+  asset: string;
+  /** Fraction, not a percentage: 0.032 == 3.2% APY. */
+  supplyApy: number;
+  /** Fraction, not a percentage. 0 when the source doesn't expose it. */
+  borrowApy: number;
+  tvlUsd: number;
+  /** 0..1. 0 when the source doesn't expose it. */
+  utilizationRate: number;
+  fetchedAt: string;
+  source: string;
+}
+
+/**
+ * A single ingestion source in the ETL pipeline. Each adapter is
+ * responsible for fetching from its upstream and normalizing into
+ * `StandardizedProtocolMetrics` — the orchestrator (`etl.service.ts`)
+ * treats every adapter identically and isolates failures per-adapter.
+ */
+export interface ProtocolAdapter {
+  readonly protocolId: string;
+  readonly displayName: string;
+  fetchMetrics(): Promise<StandardizedProtocolMetrics[]>;
+}
+
+export interface DataQualityIssue {
+  protocol: string;
+  asset: string;
+  reason: string;
+}
+
+export interface CrossProtocolComparisonResult {
+  metrics: StandardizedProtocolMetrics[];
+  qualityIssues: DataQualityIssue[];
+  /** protocolIds of adapters that errored during this refresh. */
+  failedSources: string[];
+  refreshedAt: string;
+}
+
+export interface ProtocolMarketShare {
+  protocol: string;
+  tvlUsd: number;
+  marketSharePct: number;
+}
+
+export type LeaderboardMetric = 'supplyApy' | 'borrowApy' | 'tvlUsd';
+
+export interface LeaderboardEntry {
+  rank: number;
+  protocol: string;
+  asset: string;
+  metric: LeaderboardMetric;
+  metricValue: number;
+  tvlUsd: number;
+}

--- a/api/src/types/analytics.ts
+++ b/api/src/types/analytics.ts
@@ -65,3 +65,46 @@ export interface WsAnalyticsMessage {
   data: HistoricalRatePoint | PoolUtilizationPoint | ProtocolRevenuePoint;
   timestamp: number;
 }
+
+export type RateGranularity = 'hourly' | 'daily' | 'weekly' | 'monthly';
+
+export interface RateVolatilityPoint {
+  timestamp: string;
+  depositApyStdDev: number;
+  borrowApyStdDev: number;
+  windowSize: number;
+  poolAddress?: string;
+}
+
+export interface WeightedAverageRatePoint {
+  periodStart: string;
+  periodEnd: string;
+  granularity: RateGranularity;
+  weightedAvgDepositApy: number;
+  weightedAvgBorrowApy: number;
+  sampleCount: number;
+  poolAddress?: string;
+}
+
+export interface RateChangeEvent {
+  timestamp: string;
+  poolAddress?: string;
+  previousBorrowApy: number;
+  newBorrowApy: number;
+  deltaBps: number;
+  changeType: 'increase' | 'decrease';
+  /**
+   * Correlates the rate change with the governance action that caused it
+   * (e.g. a parameter-store update). `undefined` when the change was
+   * derived purely from recorded rate snapshots without a matching
+   * governance event in range — see `analytics.service.ts`.
+   */
+  governanceActionId?: string;
+}
+
+export interface RateHistoryQuery {
+  asset?: string;
+  from?: string;
+  to?: string;
+  granularity?: RateGranularity;
+}

--- a/stellar-lend/Cargo.lock
+++ b/stellar-lend/Cargo.lock
@@ -1477,7 +1477,7 @@ version = "0.1.0"
 dependencies = [
  "lending-types",
  "soroban-sdk",
- "test-utils",
+ "stellarlend-safe-math",
 ]
 
 [[package]]

--- a/stellar-lend/Cargo.toml
+++ b/stellar-lend/Cargo.toml
@@ -40,7 +40,12 @@ members = [
   "contracts/token-adapter",
   "contracts/compliance",
 ]
-exclude = ["fuzz", "formal-verification/safe-math-proofs"]
+exclude = [
+  "fuzz",
+  "formal-verification/safe-math-proofs",
+  "formal-verification/interest-rate-model-proofs",
+  "formal-verification/liquidation-math-proofs",
+]
 
 [workspace.lints.rust]
 

--- a/stellar-lend/contracts/lending-risk/Cargo.toml
+++ b/stellar-lend/contracts/lending-risk/Cargo.toml
@@ -9,9 +9,7 @@ crate-type = ["lib"]
 [dependencies]
 soroban-sdk = { workspace = true }
 lending-types = { path = "../lending-types" }
-
-[dev-dependencies]
-test-utils = { path = "../test-utils" }
+stellarlend-safe-math = { workspace = true }
 
 [features]
 default = []

--- a/stellar-lend/contracts/lending-risk/src/lib.rs
+++ b/stellar-lend/contracts/lending-risk/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 
 use lending_types::{calculate_health_factor, is_healthy, BPS_DIVISOR};
-use soroban_sdk::{Address, Env};
+use stellarlend_safe_math::{safe_add, safe_div, safe_mul, safe_sub, MathError};
 
 pub struct RiskManager;
 
@@ -16,12 +16,18 @@ impl RiskManager {
         !is_healthy(health_factor)
     }
 
-    pub fn calculate_liquidation_bonus(debt_amount: i128, bonus_bps: i128) -> i128 {
-        debt_amount * bonus_bps / BPS_DIVISOR
+    pub fn calculate_liquidation_bonus(
+        debt_amount: i128,
+        bonus_bps: i128,
+    ) -> Result<i128, MathError> {
+        safe_mul(debt_amount, bonus_bps).and_then(|v| safe_div(v, BPS_DIVISOR))
     }
 
-    pub fn calculate_max_liquidatable(debt_value: i128, close_factor_bps: i128) -> i128 {
-        debt_value * close_factor_bps / BPS_DIVISOR
+    pub fn calculate_max_liquidatable(
+        debt_value: i128,
+        close_factor_bps: i128,
+    ) -> Result<i128, MathError> {
+        safe_mul(debt_value, close_factor_bps).and_then(|v| safe_div(v, BPS_DIVISOR))
     }
 
     pub fn validate_borrow_capacity(
@@ -29,29 +35,80 @@ impl RiskManager {
         existing_debt: i128,
         new_borrow: i128,
         collateral_factor_bps: i128,
-    ) -> bool {
-        let max_borrow = collateral_value * collateral_factor_bps / BPS_DIVISOR;
-        existing_debt + new_borrow <= max_borrow
+    ) -> Result<bool, MathError> {
+        let max_borrow =
+            safe_mul(collateral_value, collateral_factor_bps).and_then(|v| safe_div(v, BPS_DIVISOR))?;
+        let total_debt = safe_add(existing_debt, new_borrow)?;
+        Ok(total_debt <= max_borrow)
     }
 
-    pub fn calculate_ltv(debt_value: i128, collateral_value: i128) -> i128 {
+    pub fn calculate_ltv(debt_value: i128, collateral_value: i128) -> Result<i128, MathError> {
         if collateral_value == 0 {
-            return BPS_DIVISOR;
+            return Ok(BPS_DIVISOR);
         }
-        debt_value * BPS_DIVISOR / collateral_value
+        safe_mul(debt_value, BPS_DIVISOR).and_then(|v| safe_div(v, collateral_value))
     }
 
     pub fn check_concentration_risk(
         asset_value: i128,
         total_pool_value: i128,
         max_concentration_bps: i128,
-    ) -> bool {
+    ) -> Result<bool, MathError> {
         if total_pool_value == 0 {
-            return true;
+            return Ok(true);
         }
-        let concentration = asset_value * BPS_DIVISOR / total_pool_value;
-        concentration <= max_concentration_bps
+        let concentration =
+            safe_mul(asset_value, BPS_DIVISOR).and_then(|v| safe_div(v, total_pool_value))?;
+        Ok(concentration <= max_concentration_bps)
     }
+
+    /// Simulates a partial liquidation of an under-collateralized position.
+    ///
+    /// A liquidator repays `repay_amount` of the position's debt and, in
+    /// exchange, seizes collateral equal to the repaid amount plus a
+    /// liquidation bonus (the standard Aave/Compound-style liquidation
+    /// incentive: `seized = repay_amount * (1 + bonus_bps / 10_000)`).
+    ///
+    /// Returns `Err` — rather than panicking or silently clamping — for any
+    /// input that would violate protocol solvency: repaying more than the
+    /// outstanding debt, or seizing more collateral than the position holds.
+    pub fn apply_liquidation(
+        collateral_value: i128,
+        debt_value: i128,
+        repay_amount: i128,
+        liquidation_bonus_bps: i128,
+    ) -> Result<LiquidationOutcome, MathError> {
+        if repay_amount < 0 || repay_amount > debt_value {
+            return Err(MathError::Underflow);
+        }
+
+        let bonus = Self::calculate_liquidation_bonus(repay_amount, liquidation_bonus_bps)?;
+        let seized_collateral = safe_add(repay_amount, bonus)?;
+
+        if seized_collateral > collateral_value {
+            return Err(MathError::Underflow);
+        }
+
+        let new_collateral_value = safe_sub(collateral_value, seized_collateral)?;
+        let new_debt_value = safe_sub(debt_value, repay_amount)?;
+
+        Ok(LiquidationOutcome {
+            new_collateral_value,
+            new_debt_value,
+            seized_collateral,
+            liquidator_profit: bonus,
+        })
+    }
+}
+
+/// Resulting position state and liquidator payout from
+/// [`RiskManager::apply_liquidation`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LiquidationOutcome {
+    pub new_collateral_value: i128,
+    pub new_debt_value: i128,
+    pub seized_collateral: i128,
+    pub liquidator_profit: i128,
 }
 
 pub struct RiskMetrics {
@@ -67,24 +124,31 @@ impl RiskMetrics {
         debt_value: i128,
         collateral_factor_bps: i128,
         liquidation_threshold_bps: i128,
-    ) -> Self {
+    ) -> Result<Self, MathError> {
         let health_factor =
             calculate_health_factor(collateral_value, debt_value, liquidation_threshold_bps);
-        let ltv_ratio = RiskManager::calculate_ltv(debt_value, collateral_value);
-        let borrow_capacity = collateral_value * collateral_factor_bps / BPS_DIVISOR;
+        let ltv_ratio = RiskManager::calculate_ltv(debt_value, collateral_value)?;
+        let borrow_capacity =
+            safe_mul(collateral_value, collateral_factor_bps).and_then(|v| safe_div(v, BPS_DIVISOR))?;
 
         let liquidation_price = if collateral_value > 0 {
-            debt_value * BPS_DIVISOR / (collateral_value * liquidation_threshold_bps / BPS_DIVISOR)
+            let effective_collateral =
+                safe_mul(collateral_value, liquidation_threshold_bps).and_then(|v| safe_div(v, BPS_DIVISOR))?;
+            if effective_collateral == 0 {
+                0
+            } else {
+                safe_mul(debt_value, BPS_DIVISOR).and_then(|v| safe_div(v, effective_collateral))?
+            }
         } else {
             0
         };
 
-        Self {
+        Ok(Self {
             health_factor,
             ltv_ratio,
             liquidation_price,
             borrow_capacity,
-        }
+        })
     }
 }
 
@@ -104,41 +168,74 @@ mod tests {
 
     #[test]
     fn test_liquidation_bonus() {
-        let bonus = RiskManager::calculate_liquidation_bonus(100_000, 500);
+        let bonus = RiskManager::calculate_liquidation_bonus(100_000, 500).unwrap();
         assert_eq!(bonus, 5_000);
     }
 
     #[test]
     fn test_ltv_calculation() {
-        assert_eq!(RiskManager::calculate_ltv(50_000, 100_000), 5_000);
-        assert_eq!(RiskManager::calculate_ltv(80_000, 100_000), 8_000);
+        assert_eq!(RiskManager::calculate_ltv(50_000, 100_000).unwrap(), 5_000);
+        assert_eq!(RiskManager::calculate_ltv(80_000, 100_000).unwrap(), 8_000);
     }
 
     #[test]
     fn test_borrow_capacity() {
-        assert!(RiskManager::validate_borrow_capacity(
-            100_000, 50_000, 10_000, 7_500
-        ));
-        assert!(!RiskManager::validate_borrow_capacity(
-            100_000, 70_000, 10_000, 7_500
-        ));
+        assert!(RiskManager::validate_borrow_capacity(100_000, 50_000, 10_000, 7_500).unwrap());
+        assert!(!RiskManager::validate_borrow_capacity(100_000, 70_000, 10_000, 7_500).unwrap());
     }
 
     #[test]
     fn test_concentration_risk() {
-        assert!(RiskManager::check_concentration_risk(
-            30_000, 100_000, 5_000
-        ));
-        assert!(!RiskManager::check_concentration_risk(
-            60_000, 100_000, 5_000
-        ));
+        assert!(RiskManager::check_concentration_risk(30_000, 100_000, 5_000).unwrap());
+        assert!(!RiskManager::check_concentration_risk(60_000, 100_000, 5_000).unwrap());
     }
 
     #[test]
     fn test_risk_metrics() {
-        let metrics = RiskMetrics::calculate(100_000, 50_000, 7_500, 8_000);
+        let metrics = RiskMetrics::calculate(100_000, 50_000, 7_500, 8_000).unwrap();
         assert_eq!(metrics.ltv_ratio, 5_000);
         assert!(metrics.health_factor > 10_000);
         assert_eq!(metrics.borrow_capacity, 75_000);
+    }
+
+    #[test]
+    fn test_apply_liquidation_improves_health_factor() {
+        // Unhealthy position: collateral 100_000, debt 90_000, threshold 80%.
+        let threshold_bps = 8_000;
+        let before = calculate_health_factor(100_000, 90_000, threshold_bps);
+        assert!(before < BPS_DIVISOR);
+
+        let outcome = RiskManager::apply_liquidation(100_000, 90_000, 40_000, 500).unwrap();
+        let after = calculate_health_factor(
+            outcome.new_collateral_value,
+            outcome.new_debt_value,
+            threshold_bps,
+        );
+        assert!(after > before, "liquidation must improve health factor");
+    }
+
+    #[test]
+    fn test_apply_liquidation_profit_matches_bonus() {
+        let outcome = RiskManager::apply_liquidation(100_000, 90_000, 40_000, 500).unwrap();
+        assert_eq!(outcome.liquidator_profit, 2_000); // 40_000 * 500 / 10_000
+        assert_eq!(outcome.seized_collateral, 42_000);
+        assert_eq!(outcome.new_debt_value, 50_000);
+        assert_eq!(outcome.new_collateral_value, 58_000);
+    }
+
+    #[test]
+    fn test_apply_liquidation_rejects_overpayment() {
+        assert!(RiskManager::apply_liquidation(100_000, 90_000, 90_001, 500).is_err());
+    }
+
+    #[test]
+    fn test_apply_liquidation_rejects_insufficient_collateral() {
+        // Seizing repay + bonus would exceed available collateral.
+        assert!(RiskManager::apply_liquidation(40_000, 90_000, 39_000, 500).is_err());
+    }
+
+    #[test]
+    fn test_liquidation_bonus_overflow_is_err() {
+        assert!(RiskManager::calculate_liquidation_bonus(i128::MAX, i128::MAX).is_err());
     }
 }

--- a/stellar-lend/contracts/safe-math/src/mul_div.rs
+++ b/stellar-lend/contracts/safe-math/src/mul_div.rs
@@ -26,7 +26,7 @@ pub fn mul_div_round_up(
     let b256 = I256::from_i128(env, b);
     let d256 = I256::from_i128(env, denominator);
     let product = a256.mul(&b256);
-    let remainder = product.rem(&d256);
+    let remainder = product.rem_euclid(&d256);
     let result = product.div(&d256);
     let zero = I256::from_i128(env, 0);
     if remainder > zero {

--- a/stellar-lend/contracts/safe-math/src/precision.rs
+++ b/stellar-lend/contracts/safe-math/src/precision.rs
@@ -1,5 +1,6 @@
-use soroban_sdk::Env;
+use soroban_sdk::{contracttype, Env};
 
+#[contracttype]
 #[derive(Clone, Debug, PartialEq)]
 pub struct PrecisionLoss {
     pub operation: i128,

--- a/stellar-lend/formal-verification/interest-rate-model-proofs/Cargo.toml
+++ b/stellar-lend/formal-verification/interest-rate-model-proofs/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "interest-rate-model-proofs"
+version = "0.1.0"
+edition = "2021"
+description = "Kani proof harnesses for the StellarLend interest rate model boundary conditions"
+
+# This crate is NOT part of the main workspace.  Run verification with:
+#   cargo kani --manifest-path formal-verification/interest-rate-model-proofs/Cargo.toml
+#   cargo test --manifest-path formal-verification/interest-rate-model-proofs/Cargo.toml
+
+[dependencies]
+lending-interest = { path = "../../contracts/lending-interest" }
+stellarlend-safe-math = { path = "../../contracts/safe-math" }
+soroban-sdk = "23.4.1"
+
+# No `kani` crate dependency is declared here: `cargo kani` injects the
+# `kani` crate/cfg via its own sysroot automatically. See the sibling
+# `safe-math-proofs/Cargo.toml` for the full rationale.

--- a/stellar-lend/formal-verification/interest-rate-model-proofs/README.md
+++ b/stellar-lend/formal-verification/interest-rate-model-proofs/README.md
@@ -1,0 +1,49 @@
+# interest-rate-model-proofs
+
+Formal verification of `InterestRateModel::calculate_borrow_rate` /
+`calculate_supply_rate` (`contracts/lending-interest`) at boundary
+conditions: 0% utilization, 100% utilization, and the kink point.
+
+This crate is **not** part of the main Cargo workspace (see the root
+`Cargo.toml` `exclude` list), matching the existing
+`formal-verification/safe-math-proofs` pattern, so it doesn't affect normal
+`cargo build`/`cargo test` runs of the contract workspace.
+
+## Running
+
+Bounded property tests (fast, run in normal CI, no extra tooling):
+
+```sh
+cargo test --manifest-path formal-verification/interest-rate-model-proofs/Cargo.toml
+```
+
+Exhaustive bounded model checking with [Kani](https://model-checking.github.io/kani/):
+
+```sh
+cargo install --locked kani-verifier
+cargo kani setup
+cargo kani --manifest-path formal-verification/interest-rate-model-proofs/Cargo.toml
+```
+
+SMT-LIB spec directly with Z3:
+
+```sh
+z3 formal-verification/interest-rate-model-proofs/interest_rate_model.smt2
+```
+
+## Properties verified
+
+1. `rate(0%) == base_rate` — no discontinuity at the origin.
+2. `rate(u)` is bounded above by `rate(100%)` for all valid `u`.
+3. `rate(u)` is monotonically non-decreasing in `u`.
+4. The below-kink and above-kink formulas agree exactly at
+   `u == optimal_utilization` (no value discontinuity at the kink).
+5. No overflow/underflow for realistic rate-parameter magnitudes across the
+   full valid utilization domain `[0, 10_000]` bps.
+6. `0 <= supply_rate <= borrow_rate` for all valid `reserve_factor` inputs.
+7. The discretized (trapezoidal) area under the rate curve over
+   `[0, 10_000]` matches the closed-form area of the two line segments.
+
+See `src/lib.rs` for a note on why literal "derivative continuity" at the
+kink is not a target property — the kink's entire purpose is an intentional
+slope change from `slope1` to `slope2`.

--- a/stellar-lend/formal-verification/interest-rate-model-proofs/interest_rate_model.smt2
+++ b/stellar-lend/formal-verification/interest-rate-model-proofs/interest_rate_model.smt2
@@ -1,0 +1,153 @@
+; ============================================================================
+; interest_rate_model.smt2 — SMT-LIB 2 specifications for the StellarLend
+; two-slope ("kinked") interest rate model
+;
+; Tool: Z3 >= 4.12  (also compatible with CVC5)
+; Run:  z3 interest_rate_model.smt2
+;
+; Each (check-sat) should return "unsat", proving the negation of the safety
+; property is unsatisfiable — i.e., the property holds for ALL inputs in the
+; declared ranges.
+;
+; Model (see contracts/lending-interest/src/lib.rs,
+; InterestRateModel::calculate_borrow_rate):
+;
+;   u <= optimal:  rate(u) = base + (u * slope1) div BPS
+;   u >  optimal:  rate(u) = base + (optimal * slope1) div BPS
+;                              + ((u - optimal) * slope2) div BPS
+;
+; We use integer division truncating toward zero, matching Rust's `/` on
+; non-negative i128 operands (all quantities here are non-negative bps
+; values, so truncating and floor division coincide).
+; ============================================================================
+
+(set-logic QF_NIA)
+
+(define-const BPS Int 10000)
+(define-const MAX_PARAM Int 1000000000000) ; realistic bound, see lib.rs
+
+(define-fun in_range_util ((u Int)) Bool
+  (and (>= u 0) (<= u BPS)))
+
+(define-fun in_range_param ((p Int)) Bool
+  (and (>= p 0) (<= p MAX_PARAM)))
+
+; rate(u) as an uninterpreted relation constrained by the two-branch
+; definition below (declared once per proof block to keep each (push)/(pop)
+; scope self-contained).
+
+; ============================================================================
+; 1. Boundary at 0% utilization: rate(0) == base_rate
+; ============================================================================
+(push)
+(declare-const base Int)
+(declare-const slope1 Int)
+(declare-const slope2 Int)
+(declare-const optimal Int)
+(assert (in_range_param base))
+(assert (in_range_param slope1))
+(assert (in_range_param slope2))
+(assert (in_range_util optimal))
+
+; rate(0): since 0 <= optimal always, below-kink branch applies.
+(declare-const rate0 Int)
+(assert (= rate0 (+ base (div (* 0 slope1) BPS))))
+
+; Negation of the property: rate(0) != base
+(assert (not (= rate0 base)))
+(check-sat) ; expect unsat
+(pop)
+
+; ============================================================================
+; 2. Monotonicity: u1 <= u2  =>  rate(u1) <= rate(u2)
+;
+; Encoded directly over the two-branch definition (case split via ite).
+; ============================================================================
+(push)
+(declare-const base Int)
+(declare-const slope1 Int)
+(declare-const slope2 Int)
+(declare-const optimal Int)
+(assert (in_range_param base))
+(assert (in_range_param slope1))
+(assert (in_range_param slope2))
+(assert (in_range_util optimal))
+
+(declare-const u1 Int)
+(declare-const u2 Int)
+(assert (in_range_util u1))
+(assert (in_range_util u2))
+(assert (<= u1 u2))
+
+(define-fun rate ((u Int)) Int
+  (ite (<= u optimal)
+       (+ base (div (* u slope1) BPS))
+       (+ base (div (* optimal slope1) BPS) (div (* (- u optimal) slope2) BPS))))
+
+(declare-const r1 Int)
+(declare-const r2 Int)
+(assert (= r1 (rate u1)))
+(assert (= r2 (rate u2)))
+
+; Negation of the property: r1 > r2
+(assert (> r1 r2))
+(check-sat) ; expect unsat
+(pop)
+
+; ============================================================================
+; 3. Kink continuity: value at u == optimal is single-valued (the two branch
+;    definitions agree at the boundary point by construction — this checks
+;    that no alternative "above-kink formula evaluated with excess=0" would
+;    diverge from the actual below-kink result).
+; ============================================================================
+(push)
+(declare-const base Int)
+(declare-const slope1 Int)
+(declare-const slope2 Int)
+(declare-const optimal Int)
+(assert (in_range_param base))
+(assert (in_range_param slope1))
+(assert (in_range_param slope2))
+(assert (in_range_util optimal))
+
+(declare-const below_formula_at_kink Int)
+(assert (= below_formula_at_kink (+ base (div (* optimal slope1) BPS))))
+
+(declare-const above_formula_zero_excess Int)
+(assert (= above_formula_zero_excess (+ base (div (* optimal slope1) BPS) (div (* 0 slope2) BPS))))
+
+; Negation: the two formulas disagree at the kink.
+(assert (not (= below_formula_at_kink above_formula_zero_excess)))
+(check-sat) ; expect unsat
+(pop)
+
+; ============================================================================
+; 4. Bounded above by rate(100%): follows directly from monotonicity (2),
+;    instantiated at u2 = BPS.
+; ============================================================================
+(push)
+(declare-const base Int)
+(declare-const slope1 Int)
+(declare-const slope2 Int)
+(declare-const optimal Int)
+(assert (in_range_param base))
+(assert (in_range_param slope1))
+(assert (in_range_param slope2))
+(assert (in_range_util optimal))
+
+(declare-const u Int)
+(assert (in_range_util u))
+
+(define-fun rate2 ((x Int)) Int
+  (ite (<= x optimal)
+       (+ base (div (* x slope1) BPS))
+       (+ base (div (* optimal slope1) BPS) (div (* (- x optimal) slope2) BPS))))
+
+(declare-const r_u Int)
+(declare-const r_max Int)
+(assert (= r_u (rate2 u)))
+(assert (= r_max (rate2 BPS)))
+
+(assert (> r_u r_max))
+(check-sat) ; expect unsat
+(pop)

--- a/stellar-lend/formal-verification/interest-rate-model-proofs/src/lib.rs
+++ b/stellar-lend/formal-verification/interest-rate-model-proofs/src/lib.rs
@@ -1,0 +1,423 @@
+//! # Kani proof harnesses for `lending-interest`'s `InterestRateModel`
+//!
+//! ## Running
+//!
+//! ```sh
+//! # Bounded unit/property tests (fast, no extra tooling required):
+//! cargo test --manifest-path formal-verification/interest-rate-model-proofs/Cargo.toml
+//!
+//! # Exhaustive bounded model checking (requires `cargo install kani-verifier`):
+//! cargo kani --manifest-path formal-verification/interest-rate-model-proofs/Cargo.toml
+//! ```
+//!
+//! Kani uses CBMC (C Bounded Model Checker) with a Z3/CVC5 SMT backend to
+//! exhaustively verify the properties below. See also
+//! `interest_rate_model.smt2` for the corresponding SMT-LIB 2 encoding,
+//! runnable directly with `z3 interest_rate_model.smt2`.
+//!
+//! ## Model under verification
+//!
+//! `InterestRateModel::calculate_borrow_rate` (see
+//! `contracts/lending-interest/src/lib.rs`) is a standard two-slope
+//! ("kinked") curve, expressed in basis points (1 bps = 0.01%):
+//!
+//! ```text
+//! u <= optimal:  rate(u) = base_rate + u * slope1 / 10_000
+//! u >  optimal:  rate(u) = base_rate + optimal * slope1 / 10_000
+//!                            + (u - optimal) * slope2 / 10_000
+//! ```
+//!
+//! `utilization` (`u`) is always a valid basis-point ratio in `[0, 10_000]`
+//! (0%–100%) because it is produced by `calculate_utilization`, which is
+//! itself clamped by construction (`total_borrows <= total_supply`).
+//!
+//! ## Properties verified
+//!
+//! 1. **Boundary at 0% utilization**: `rate(0) == base_rate` — no
+//!    discontinuity at the origin.
+//! 2. **Boundary at 100% utilization / monotonic maximum**: because the
+//!    curve is proven monotonically non-decreasing (property 3), `rate(u)`
+//!    is bounded above by `rate(10_000)` for every valid `u`.
+//! 3. **Monotonicity**: for any `u1 <= u2` in `[0, 10_000]`,
+//!    `rate(u1) <= rate(u2)`, given non-negative slopes.
+//! 4. **Kink continuity**: the below-kink and above-kink formulas agree
+//!    exactly at `u == optimal_utilization` (no value jump at the kink).
+//! 5. **No overflow/underflow** for realistic rate-parameter magnitudes
+//!    across the full valid utilization domain.
+//! 6. **Supply rate bounds**: `0 <= supply_rate <= borrow_rate` for valid
+//!    `reserve_factor` and `utilization` inputs.
+//! 7. **Discrete-integral sanity check**: the trapezoidal-rule area under
+//!    the (piecewise-linear) rate curve over `[0, 10_000]` matches the
+//!    closed-form area of the two line segments exactly.
+//!
+//! ## A note on "derivative continuity"
+//!
+//! The original design brief also lists "derivative of rate function is
+//! continuous (no jumps)" as a target property. That is *not* achievable
+//! (nor desirable) for a two-slope kinked model: the kink is precisely the
+//! point where the *slope* of the rate curve is intentionally allowed to
+//! jump from `slope1` to `slope2` — this is what lets the model react
+//! sharply to utilization crossing the optimal point, matching the
+//! Aave/Compound-style kinked-rate design this contract follows. What *is*
+//! required — and *is* proven here — is that the curve's **value** has no
+//! discontinuity at the kink (property 4) and that it remains monotonic
+//! (property 3) on both sides.
+
+#![cfg_attr(not(kani), allow(dead_code))]
+#![allow(unexpected_cfgs)]
+
+use lending_interest::InterestRateModel;
+
+/// Basis-point scale used throughout the protocol (10_000 bps == 100%).
+const BPS: i128 = 10_000;
+
+/// Realistic upper bound on rate-model parameters used for the bounded
+/// overflow proofs. Real deployments configure `base_rate`/`slope1`/`slope2`
+/// on the order of a few thousand bps (tens of percent); this bound is
+/// generous (10^12 bps == 10^8 %) while still keeping intermediate products
+/// (`param * 10_000`) far from the i128 range limit, so the proof result is
+/// meaningful rather than vacuous.
+const MAX_REALISTIC_PARAM: i128 = 1_000_000_000_000;
+
+/// Used only by `#[cfg(kani)]` proof harnesses below; unused (by design)
+/// under plain `cargo test`, since those harnesses only run under `cargo kani`.
+fn valid_model(m: &InterestRateModel) -> bool {
+    m.base_rate >= 0
+        && m.slope1 >= 0
+        && m.slope2 >= 0
+        && m.base_rate <= MAX_REALISTIC_PARAM
+        && m.slope1 <= MAX_REALISTIC_PARAM
+        && m.slope2 <= MAX_REALISTIC_PARAM
+        && m.optimal_utilization >= 0
+        && m.optimal_utilization <= BPS
+}
+
+// ── Property 1: rate(0) == base_rate ─────────────────────────────────────────
+
+#[cfg(kani)]
+#[kani::proof]
+fn kani_rate_zero_utilization_equals_base_rate() {
+    let model = InterestRateModel {
+        base_rate: kani::any(),
+        slope1: kani::any(),
+        slope2: kani::any(),
+        optimal_utilization: kani::any(),
+    };
+    kani::assume(valid_model(&model));
+
+    let rate = model.calculate_borrow_rate(0).unwrap();
+    kani::assert(
+        rate == model.base_rate,
+        "rate(0%) must equal base_rate exactly (no discontinuity at origin)",
+    );
+}
+
+// ── Property 3: monotonicity ─────────────────────────────────────────────────
+
+#[cfg(kani)]
+#[kani::proof]
+fn kani_rate_monotonic_in_utilization() {
+    let model = InterestRateModel {
+        base_rate: kani::any(),
+        slope1: kani::any(),
+        slope2: kani::any(),
+        optimal_utilization: kani::any(),
+    };
+    kani::assume(valid_model(&model));
+
+    let u1: i128 = kani::any();
+    let u2: i128 = kani::any();
+    kani::assume(u1 >= 0 && u1 <= BPS);
+    kani::assume(u2 >= 0 && u2 <= BPS);
+    kani::assume(u1 <= u2);
+
+    let r1 = model.calculate_borrow_rate(u1).unwrap();
+    let r2 = model.calculate_borrow_rate(u2).unwrap();
+
+    kani::assert(
+        r1 <= r2,
+        "borrow rate must be monotonically non-decreasing in utilization",
+    );
+}
+
+// ── Property 2: rate(u) is bounded above by rate(100%) ───────────────────────
+
+#[cfg(kani)]
+#[kani::proof]
+fn kani_rate_bounded_above_by_max_utilization() {
+    let model = InterestRateModel {
+        base_rate: kani::any(),
+        slope1: kani::any(),
+        slope2: kani::any(),
+        optimal_utilization: kani::any(),
+    };
+    kani::assume(valid_model(&model));
+
+    let u: i128 = kani::any();
+    kani::assume(u >= 0 && u <= BPS);
+
+    let r = model.calculate_borrow_rate(u).unwrap();
+    let r_max = model.calculate_borrow_rate(BPS).unwrap();
+
+    kani::assert(
+        r <= r_max,
+        "rate(u) must never exceed rate(100% utilization)",
+    );
+}
+
+// ── Property 4: kink continuity ──────────────────────────────────────────────
+
+#[cfg(kani)]
+#[kani::proof]
+fn kani_rate_continuous_at_kink() {
+    let model = InterestRateModel {
+        base_rate: kani::any(),
+        slope1: kani::any(),
+        slope2: kani::any(),
+        optimal_utilization: kani::any(),
+    };
+    kani::assume(valid_model(&model));
+
+    // Value exactly at the kink, taken via the below-kink branch
+    // (utilization <= optimal always takes the below-kink path).
+    let at_kink = model.calculate_borrow_rate(model.optimal_utilization).unwrap();
+
+    // One bps above the kink takes the above-kink branch with excess == 1.
+    // As excess -> 0 the above-kink formula's constant term must equal
+    // `at_kink` exactly, i.e. there is no jump in the curve's value.
+    if model.optimal_utilization < BPS {
+        let just_above = model
+            .calculate_borrow_rate(model.optimal_utilization + 1)
+            .unwrap();
+        kani::assert(
+            just_above >= at_kink,
+            "value must not jump backwards immediately above the kink",
+        );
+        // The jump from at_kink to just_above is bounded by one bps of slope2
+        // (no larger discontinuity than the model's own step size).
+        kani::assert(
+            just_above - at_kink <= (model.slope2 / BPS) + 1,
+            "no unexpected value discontinuity at the kink",
+        );
+    }
+}
+
+// ── Property 5: no overflow for realistic parameters ─────────────────────────
+
+#[cfg(kani)]
+#[kani::proof]
+fn kani_no_overflow_for_realistic_params() {
+    let model = InterestRateModel {
+        base_rate: kani::any(),
+        slope1: kani::any(),
+        slope2: kani::any(),
+        optimal_utilization: kani::any(),
+    };
+    kani::assume(valid_model(&model));
+
+    let u: i128 = kani::any();
+    kani::assume(u >= 0 && u <= BPS);
+
+    // Must never panic and must never silently overflow — always Ok for
+    // realistic parameter magnitudes across the whole valid domain.
+    let result = model.calculate_borrow_rate(u);
+    kani::assert(
+        result.is_ok(),
+        "calculate_borrow_rate must not overflow for realistic parameters",
+    );
+}
+
+// ── Property 6: supply rate bounds ───────────────────────────────────────────
+
+#[cfg(kani)]
+#[kani::proof]
+fn kani_supply_rate_bounded_by_borrow_rate() {
+    let model = InterestRateModel {
+        base_rate: kani::any(),
+        slope1: kani::any(),
+        slope2: kani::any(),
+        optimal_utilization: kani::any(),
+    };
+    kani::assume(valid_model(&model));
+
+    let u: i128 = kani::any();
+    kani::assume(u >= 0 && u <= BPS);
+    let borrow_rate = match model.calculate_borrow_rate(u) {
+        Ok(r) => r,
+        Err(_) => return,
+    };
+
+    let reserve_factor: i128 = kani::any();
+    kani::assume(reserve_factor >= 0 && reserve_factor <= BPS);
+
+    let supply_rate = model
+        .calculate_supply_rate(borrow_rate, u, reserve_factor)
+        .unwrap();
+
+    kani::assert(supply_rate >= 0, "supply rate must never be negative");
+    kani::assert(
+        supply_rate <= borrow_rate,
+        "supply rate must never exceed the borrow rate paying for it",
+    );
+}
+
+// ── Non-kani unit/property tests (always compiled, run via `cargo test`) ────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_model() -> InterestRateModel {
+        InterestRateModel {
+            base_rate: 200,
+            slope1: 400,
+            slope2: 6_000,
+            optimal_utilization: 8_000,
+        }
+    }
+
+    #[test]
+    fn boundary_zero_utilization_equals_base_rate() {
+        let model = sample_model();
+        assert_eq!(model.calculate_borrow_rate(0).unwrap(), model.base_rate);
+    }
+
+    #[test]
+    fn boundary_full_utilization_is_the_maximum() {
+        let model = sample_model();
+        let r_max = model.calculate_borrow_rate(BPS).unwrap();
+        for u in (0..=BPS).step_by(137) {
+            let r = model.calculate_borrow_rate(u).unwrap();
+            assert!(r <= r_max, "rate({u}) = {r} exceeded rate(100%) = {r_max}");
+        }
+    }
+
+    #[test]
+    fn monotonic_increasing_spot_check() {
+        let model = sample_model();
+        let mut prev = model.calculate_borrow_rate(0).unwrap();
+        for u in (0..=BPS).step_by(50) {
+            let r = model.calculate_borrow_rate(u).unwrap();
+            assert!(r >= prev, "rate decreased at u={u}: {r} < {prev}");
+            prev = r;
+        }
+    }
+
+    #[test]
+    fn kink_behavior_matches_expected_slope_change() {
+        let model = sample_model();
+        // Single-bps deltas are swamped by bps-floor-division rounding
+        // noise, so compare the average marginal rate over a wider window
+        // on each side of the kink instead — this is what "kink behavior"
+        // (slope1 below, steeper slope2 above) actually means.
+        const WINDOW: i128 = 500;
+        let below = model
+            .calculate_borrow_rate(model.optimal_utilization - WINDOW)
+            .unwrap();
+        let at = model.calculate_borrow_rate(model.optimal_utilization).unwrap();
+        let above = model
+            .calculate_borrow_rate(model.optimal_utilization + WINDOW)
+            .unwrap();
+
+        let avg_slope_below = at - below;
+        let avg_slope_above = above - at;
+
+        // slope2 (6_000) >> slope1 (400) in the sample model, so the rate
+        // must climb noticeably faster above the kink than below it.
+        assert!(
+            avg_slope_above > avg_slope_below,
+            "expected steeper rate increase above the kink: below={avg_slope_below} above={avg_slope_above}"
+        );
+
+        // No value discontinuity: one bps above the kink is within one
+        // slope2-step of the value exactly at the kink.
+        let just_above = model
+            .calculate_borrow_rate(model.optimal_utilization + 1)
+            .unwrap();
+        assert!(just_above >= at);
+        assert!(just_above - at <= model.slope2 / BPS + 1);
+    }
+
+    #[test]
+    fn no_overflow_at_extreme_parameters_returns_err_not_panic() {
+        let model = InterestRateModel {
+            base_rate: i128::MAX,
+            slope1: i128::MAX,
+            slope2: i128::MAX,
+            optimal_utilization: 8_000,
+        };
+        // Must return Err, never panic.
+        assert!(model.calculate_borrow_rate(5_000).is_err());
+        assert!(model.calculate_borrow_rate(0).is_ok()); // 0 * anything = 0, no mult needed on this path... still must not panic
+    }
+
+    #[test]
+    fn no_overflow_for_realistic_params_across_domain() {
+        let model = sample_model();
+        for u in (0..=BPS).step_by(97) {
+            assert!(model.calculate_borrow_rate(u).is_ok());
+        }
+    }
+
+    #[test]
+    fn supply_rate_never_exceeds_borrow_rate() {
+        let model = sample_model();
+        for u in (0..=BPS).step_by(211) {
+            let borrow_rate = model.calculate_borrow_rate(u).unwrap();
+            for reserve_factor in [0, 1_000, 5_000, 9_000, 10_000] {
+                let supply_rate = model
+                    .calculate_supply_rate(borrow_rate, u, reserve_factor)
+                    .unwrap();
+                assert!(supply_rate >= 0);
+                assert!(supply_rate <= borrow_rate);
+            }
+        }
+    }
+
+    /// Property 7: discrete-integral sanity check.
+    ///
+    /// For a piecewise-linear function, the trapezoidal rule is *exact*
+    /// (zero approximation error) regardless of step size, as long as
+    /// sample points include the kink itself. This test verifies the
+    /// discretized area (Riemann/trapezoid sum over bps-resolution samples)
+    /// matches the closed-form area of the two line segments, up to integer
+    /// rounding from the model's own bps-floor-division.
+    #[test]
+    fn integral_of_rate_curve_matches_closed_form_area() {
+        let model = sample_model();
+
+        // Closed-form area (trapezoidal, in bps * bps units) of the two
+        // linear segments: base + slope-scaled trapezoids.
+        let r0 = model.calculate_borrow_rate(0).unwrap();
+        let r_kink = model.calculate_borrow_rate(model.optimal_utilization).unwrap();
+        let r_max = model.calculate_borrow_rate(BPS).unwrap();
+
+        let area_below = (r0 + r_kink) * model.optimal_utilization / 2;
+        let area_above = (r_kink + r_max) * (BPS - model.optimal_utilization) / 2;
+        let expected_area = area_below + area_above;
+
+        // Discrete trapezoidal sum over unit-bps steps.
+        let mut discrete_area: i128 = 0;
+        let mut prev = r0;
+        for u in 1..=BPS {
+            let r = model.calculate_borrow_rate(u).unwrap();
+            discrete_area += (prev + r) / 2;
+            prev = r;
+        }
+
+        // Allow small integer-rounding slack proportional to the number of
+        // samples (each trapezoid can round down by at most 1 unit).
+        let tolerance = BPS;
+        assert!(
+            (discrete_area - expected_area).abs() <= tolerance,
+            "discrete area {discrete_area} deviated from closed-form area {expected_area} by more than {tolerance}"
+        );
+    }
+
+    #[test]
+    fn utilization_out_of_range_still_does_not_panic() {
+        let model = sample_model();
+        // Negative utilization: below-kink branch, should not panic.
+        assert!(model.calculate_borrow_rate(-1).is_ok());
+    }
+}

--- a/stellar-lend/formal-verification/liquidation-math-proofs/Cargo.toml
+++ b/stellar-lend/formal-verification/liquidation-math-proofs/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "liquidation-math-proofs"
+version = "0.1.0"
+edition = "2021"
+description = "Kani proof harnesses for StellarLend liquidation math invariants (lending-risk)"
+
+# This crate is NOT part of the main workspace.  Run verification with:
+#   cargo kani --manifest-path formal-verification/liquidation-math-proofs/Cargo.toml
+#   cargo test --manifest-path formal-verification/liquidation-math-proofs/Cargo.toml
+
+[dependencies]
+lending-risk = { path = "../../contracts/lending-risk" }
+lending-types = { path = "../../contracts/lending-types" }
+stellarlend-safe-math = { path = "../../contracts/safe-math" }
+soroban-sdk = "23.4.1"
+
+# No `kani` crate dependency is declared here: `cargo kani` injects the
+# `kani` crate/cfg via its own sysroot automatically. See
+# `formal-verification/safe-math-proofs/Cargo.toml` for the full rationale.

--- a/stellar-lend/formal-verification/liquidation-math-proofs/README.md
+++ b/stellar-lend/formal-verification/liquidation-math-proofs/README.md
@@ -1,0 +1,66 @@
+# liquidation-math-proofs
+
+Formal verification of `RiskManager::apply_liquidation` and the supporting
+discount/conservation math added to `contracts/lending-risk` for this
+effort.
+
+This crate is **not** part of the main Cargo workspace (see the root
+`Cargo.toml` `exclude` list), matching the existing
+`formal-verification/safe-math-proofs` pattern.
+
+## Running
+
+```sh
+# Bounded property tests (fast, run in normal CI, no extra tooling):
+cargo test --manifest-path formal-verification/liquidation-math-proofs/Cargo.toml
+
+# Exhaustive bounded model checking with Kani:
+cargo install --locked kani-verifier
+cargo kani setup
+cargo kani --manifest-path formal-verification/liquidation-math-proofs/Cargo.toml
+
+# SMT-LIB spec directly with Z3 (all five checks verified: unsat, unsat,
+# unsat, unsat, sat):
+z3 formal-verification/liquidation-math-proofs/liquidation_math.smt2
+```
+
+## Properties verified
+
+1. **Liquidation discount bounds**: `0 <= bonus <= repay_amount` for any
+   `bonus_bps` in `[0, 10_000]`.
+2. **Conservation / no value leak**: collateral and debt removed from a
+   position exactly match what the liquidator receives / what debt is
+   cleared — nothing is silently created or destroyed.
+3. **Exact liquidator payout**: `liquidator_profit` equals the configured
+   discount precisely.
+4. **The ratio condition for health-factor movement** (see below).
+5. **No silent overflow/underflow**: `apply_liquidation` is total — always
+   `Ok` with exactly the conserved values above, or `Err`, never a wrapped
+   result.
+
+## Key finding: liquidation is not unconditionally health-improving
+
+The original brief for this work assumed liquidation always leaves a
+position at least as healthy as before. **Kani (and the accompanying Z3
+witness check) show that's false** for sufficiently under-collateralized
+("bad debt") positions: the liquidator's bonus is carved out of collateral
+that's already scarcer than the debt it backs, so the health factor can
+*decrease* as a mechanical consequence of a "correct" liquidation call.
+
+The crate instead proves the precise condition (`src/lib.rs` has the full
+derivation and a concrete regression-pinned example:
+`collateral=50_000, debt=90_000, repay=40_000, bonus_bps=500` moves the
+health factor from `4444` to `1280`):
+
+```text
+collateral * repay >= debt * seized   =>   hf_after >= hf_before
+collateral * repay <  debt * seized   =>   hf_after <= hf_before
+```
+
+Any keeper/liquidation-bot logic built on top of this math should account
+for this — liquidating a position that's already below the
+`1 + bonus_bps / 10_000` collateral/debt ratio does not restore its health
+and should likely route to a different (bonus-free / bad-debt) handling
+path instead. That routing logic is out of scope for `lending-risk` itself;
+this crate's contribution is making the exact boundary provable rather than
+assumed.

--- a/stellar-lend/formal-verification/liquidation-math-proofs/liquidation_math.smt2
+++ b/stellar-lend/formal-verification/liquidation-math-proofs/liquidation_math.smt2
@@ -1,0 +1,185 @@
+; ============================================================================
+; liquidation_math.smt2 — SMT-LIB 2 specifications for StellarLend
+; liquidation math (RiskManager::apply_liquidation, contracts/lending-risk)
+;
+; Tool: Z3 >= 4.12  (also compatible with CVC5)
+; Run:  z3 liquidation_math.smt2
+;
+; Model:
+;   bonus            = (repay * bonus_bps) div BPS
+;   seized            = repay + bonus
+;   new_collateral    = collateral - seized
+;   new_debt          = debt - repay
+;   health_factor(c,d) = (c * threshold) div d      (d > 0)
+;
+; Each (check-sat) should return "unsat", proving the negation of the safety
+; property is unsatisfiable — i.e., the property holds for ALL inputs in the
+; declared ranges.
+; ============================================================================
+
+(set-logic QF_NIA)
+
+(define-const BPS Int 10000)
+(define-const MAX_VAL Int 1000000000000)
+
+(define-fun in_range_val ((x Int)) Bool
+  (and (> x 0) (<= x MAX_VAL)))
+
+(define-fun in_range_bps ((x Int)) Bool
+  (and (>= x 0) (<= x BPS)))
+
+; ============================================================================
+; 1. Liquidation discount bounds: 0 <= bonus <= repay
+; ============================================================================
+(push)
+(declare-const repay Int)
+(declare-const bonus_bps Int)
+(assert (in_range_val repay))
+(assert (in_range_bps bonus_bps))
+
+(declare-const bonus Int)
+(assert (= bonus (div (* repay bonus_bps) BPS)))
+
+(assert (not (and (>= bonus 0) (<= bonus repay))))
+(check-sat) ; expect unsat
+(pop)
+
+; ============================================================================
+; 2. Conservation: new_collateral + seized == collateral, new_debt + repay == debt
+; ============================================================================
+(push)
+(declare-const collateral Int)
+(declare-const debt Int)
+(declare-const repay Int)
+(declare-const bonus_bps Int)
+(assert (in_range_val collateral))
+(assert (in_range_val debt))
+(assert (in_range_bps bonus_bps))
+(assert (> repay 0))
+(assert (< repay debt))
+
+(declare-const bonus Int)
+(assert (= bonus (div (* repay bonus_bps) BPS)))
+(declare-const seized Int)
+(assert (= seized (+ repay bonus)))
+; Only reason about the case where the liquidation is solvent (Ok in Rust).
+(assert (<= seized collateral))
+
+(declare-const new_collateral Int)
+(declare-const new_debt Int)
+(assert (= new_collateral (- collateral seized)))
+(assert (= new_debt (- debt repay)))
+
+(assert (not (and (= (+ new_collateral seized) collateral)
+                   (= (+ new_debt repay) debt))))
+(check-sat) ; expect unsat
+(pop)
+
+; ============================================================================
+; 3. Ratio condition, direction A:
+;    collateral*repay >= debt*seized  =>  hf_after >= hf_before
+; ============================================================================
+(push)
+(declare-const collateral Int)
+(declare-const debt Int)
+(declare-const repay Int)
+(declare-const bonus_bps Int)
+(declare-const threshold Int)
+(assert (in_range_val collateral))
+(assert (in_range_val debt))
+(assert (in_range_bps bonus_bps))
+(assert (> threshold 0))
+(assert (<= threshold BPS))
+(assert (> repay 0))
+(assert (< repay debt))
+
+(declare-const bonus Int)
+(assert (= bonus (div (* repay bonus_bps) BPS)))
+(declare-const seized Int)
+(assert (= seized (+ repay bonus)))
+(assert (<= seized collateral))
+
+(declare-const new_collateral Int)
+(declare-const new_debt Int)
+(assert (= new_collateral (- collateral seized)))
+(assert (= new_debt (- debt repay)))
+
+(declare-const hf_before Int)
+(declare-const hf_after Int)
+(assert (= hf_before (div (* collateral threshold) debt)))
+(assert (= hf_after (div (* new_collateral threshold) new_debt)))
+
+; Premise: the ratio condition holds.
+(assert (>= (* collateral repay) (* debt seized)))
+
+; Negation of the conclusion: hf_after < hf_before.
+(assert (< hf_after hf_before))
+(check-sat) ; expect unsat
+(pop)
+
+; ============================================================================
+; 4. Ratio condition, direction B:
+;    collateral*repay <  debt*seized  =>  hf_after <= hf_before
+;    (non-strict: bps-floor-division can land both sides on the same
+;    integer at the boundary — see liquidation-math-proofs/src/lib.rs)
+; ============================================================================
+(push)
+(declare-const collateral Int)
+(declare-const debt Int)
+(declare-const repay Int)
+(declare-const bonus_bps Int)
+(declare-const threshold Int)
+(assert (in_range_val collateral))
+(assert (in_range_val debt))
+(assert (in_range_bps bonus_bps))
+(assert (> threshold 0))
+(assert (<= threshold BPS))
+(assert (> repay 0))
+(assert (< repay debt))
+
+(declare-const bonus Int)
+(assert (= bonus (div (* repay bonus_bps) BPS)))
+(declare-const seized Int)
+(assert (= seized (+ repay bonus)))
+(assert (<= seized collateral))
+
+(declare-const new_collateral Int)
+(declare-const new_debt Int)
+(assert (= new_collateral (- collateral seized)))
+(assert (= new_debt (- debt repay)))
+
+(declare-const hf_before Int)
+(declare-const hf_after Int)
+(assert (= hf_before (div (* collateral threshold) debt)))
+(assert (= hf_after (div (* new_collateral threshold) new_debt)))
+
+; Premise: the ratio condition does NOT hold.
+(assert (< (* collateral repay) (* debt seized)))
+
+; Negation of the conclusion: hf_after > hf_before.
+(assert (> hf_after hf_before))
+(check-sat) ; expect unsat
+(pop)
+
+; ============================================================================
+; 5. Witness: the ratio condition CAN fail for realistic inputs (sat expected
+;    — this is a satisfiability witness, not a safety property, confirming
+;    the "liquidation can worsen health factor" finding is reachable and not
+;    vacuous).
+; ============================================================================
+(push)
+(declare-const collateral Int)
+(declare-const debt Int)
+(declare-const repay Int)
+(declare-const bonus_bps Int)
+(assert (= collateral 50000))
+(assert (= debt 90000))
+(assert (= repay 40000))
+(assert (= bonus_bps 500))
+(declare-const bonus Int)
+(assert (= bonus (div (* repay bonus_bps) BPS)))
+(declare-const seized Int)
+(assert (= seized (+ repay bonus)))
+(assert (< (* collateral repay) (* debt seized))) ; ratio condition fails here
+(check-sat) ; expect sat
+(pop)

--- a/stellar-lend/formal-verification/liquidation-math-proofs/src/lib.rs
+++ b/stellar-lend/formal-verification/liquidation-math-proofs/src/lib.rs
@@ -1,0 +1,316 @@
+//! # Kani proof harnesses for `lending-risk`'s liquidation math
+//!
+//! ## Running
+//!
+//! ```sh
+//! # Bounded unit/property tests (fast, no extra tooling required):
+//! cargo test --manifest-path formal-verification/liquidation-math-proofs/Cargo.toml
+//!
+//! # Exhaustive bounded model checking (requires `cargo install kani-verifier`):
+//! cargo kani --manifest-path formal-verification/liquidation-math-proofs/Cargo.toml
+//! ```
+//!
+//! See also `liquidation_math.smt2` for the corresponding SMT-LIB 2 encoding.
+//!
+//! ## Model under verification
+//!
+//! `RiskManager::apply_liquidation` (`contracts/lending-risk/src/lib.rs`)
+//! simulates a partial liquidation using the standard Aave/Compound-style
+//! design: a liquidator repays `repay_amount` of a position's debt and
+//! seizes `seized = repay_amount + bonus` of collateral, where
+//! `bonus = repay_amount * bonus_bps / 10_000`.
+//!
+//! ## Properties verified
+//!
+//! 1. **Liquidation discount bounds**: `0 <= bonus <= repay_amount` for any
+//!    `bonus_bps` in `[0, 10_000]` (a liquidation bonus can never exceed
+//!    100% of the repaid amount).
+//! 2. **Conservation / no value leak**: `collateral_value ==
+//!    new_collateral_value + seized_collateral` and `debt_value ==
+//!    new_debt_value + repay_amount` exactly — nothing is created or
+//!    destroyed by the liquidation math itself.
+//! 3. **Liquidator payout is exact**: `liquidator_profit == bonus` as
+//!    computed by `calculate_liquidation_bonus` — the liquidator receives
+//!    precisely the configured discount, no more, no less.
+//! 4. **Conditional health-factor monotonicity** (see note below).
+//! 5. **No silent overflow/underflow** — `apply_liquidation` either returns
+//!    `Ok` with the exact conserved values above, or `Err`, never a wrapped/
+//!    truncated result.
+//!
+//! ## An important, non-obvious finding: liquidation is not *always*
+//! ## health-improving
+//!
+//! The design brief for this verification effort assumed an unconditional
+//! invariant: "post-liquidation health factor >= pre-liquidation health
+//! factor" for *any* valid liquidation call. **That unconditional claim is
+//! false**, and Kani finds the counterexample immediately if you try to
+//! prove it as stated.
+//!
+//! Concretely: with `collateral_value = 50_000`, `debt_value = 90_000`,
+//! `repay_amount = 40_000`, `liquidation_bonus_bps = 500` — a deeply
+//! under-collateralized ("bad debt") position — the health factor
+//! (`collateral * threshold / debt`) *drops* from `4444` to `1280` after
+//! liquidation, because the liquidator's bonus is carved out of collateral
+//! that is already scarcer than the debt it backs.
+//!
+//! Working the algebra (see `kani_health_factor_ratio_condition` below and
+//! `liquidation_math.smt2`) shows the precise, *provable* condition, stated
+//! as two one-directional implications (integer floor-division means the
+//! two directions meet at equality, not a clean strict biconditional):
+//!
+//! ```text
+//! collateral_value * repay_amount >= debt_value * seized_collateral
+//!     =>  health_factor_after >= health_factor_before
+//!
+//! collateral_value * repay_amount <  debt_value * seized_collateral
+//!     =>  health_factor_after <= health_factor_before
+//! ```
+//!
+//! Equivalently, in real-number terms, the first premise is
+//! `collateral_value / debt_value >= 1 + liquidation_bonus_bps / 10_000`.
+//! i.e. liquidation only improves health when the position's raw
+//! collateral/debt ratio still exceeds the liquidation *seizure* ratio.
+//! Below that point, every liquidation call — even though individually
+//! "correct" per the discount formula — mechanically accelerates the
+//! position toward insolvency. This is a real design implication: a
+//! liquidation bot / keeper incentive layer built on top of this math
+//! should gate on this ratio (or fall back to a bonus-free/bad-debt
+//! socialization path) rather than assuming liquidation is always
+//! protective. That gating logic is out of scope for this crate (it lives
+//! above `lending-risk`, e.g. in a keeper or a future bad-debt handler) —
+//! this crate's job is to make the exact boundary precise and proven rather
+//! than asserted.
+
+#![cfg_attr(not(kani), allow(dead_code))]
+#![allow(unexpected_cfgs)]
+// Both imports are used by `#[cfg(kani)]` proof harnesses (only compiled
+// under `cargo kani`) and by the `#[cfg(test)]` unit tests via `super::*`;
+// under a plain `cargo test` build that combination still trips the lint.
+#![allow(unused_imports)]
+
+use lending_risk::RiskManager;
+use lending_types::calculate_health_factor;
+
+const BPS: i128 = 10_000;
+/// Same rationale as `interest-rate-model-proofs`: realistic magnitude bound
+/// for value/rate parameters so overflow proofs are meaningful, not vacuous.
+const MAX_REALISTIC_VALUE: i128 = 1_000_000_000_000;
+
+fn valid_position(collateral_value: i128, debt_value: i128, threshold_bps: i128) -> bool {
+    collateral_value > 0
+        && collateral_value <= MAX_REALISTIC_VALUE
+        && debt_value > 0
+        && debt_value <= MAX_REALISTIC_VALUE
+        && threshold_bps > 0
+        && threshold_bps <= BPS
+}
+
+// ── Property 1: liquidation discount bounds ──────────────────────────────────
+
+#[cfg(kani)]
+#[kani::proof]
+fn kani_liquidation_bonus_bounded() {
+    let repay_amount: i128 = kani::any();
+    let bonus_bps: i128 = kani::any();
+    kani::assume(repay_amount >= 0 && repay_amount <= MAX_REALISTIC_VALUE);
+    kani::assume(bonus_bps >= 0 && bonus_bps <= BPS);
+
+    let bonus = RiskManager::calculate_liquidation_bonus(repay_amount, bonus_bps).unwrap();
+
+    kani::assert(bonus >= 0, "liquidation bonus must never be negative");
+    kani::assert(
+        bonus <= repay_amount,
+        "liquidation bonus must never exceed 100% of the repaid amount",
+    );
+}
+
+// ── Properties 2, 3, 5: conservation, exact payout, no silent overflow ──────
+
+#[cfg(kani)]
+#[kani::proof]
+fn kani_apply_liquidation_conserves_value() {
+    let collateral_value: i128 = kani::any();
+    let debt_value: i128 = kani::any();
+    let repay_amount: i128 = kani::any();
+    let bonus_bps: i128 = kani::any();
+
+    kani::assume(valid_position(collateral_value, debt_value, BPS / 2));
+    kani::assume(repay_amount >= 0 && repay_amount <= debt_value);
+    kani::assume(bonus_bps >= 0 && bonus_bps <= BPS);
+
+    if let Ok(outcome) =
+        RiskManager::apply_liquidation(collateral_value, debt_value, repay_amount, bonus_bps)
+    {
+        // No value leak: what's removed from the position is exactly what
+        // the liquidator receives / the debt that's cleared.
+        kani::assert(
+            outcome.new_collateral_value + outcome.seized_collateral == collateral_value,
+            "collateral conservation: new_collateral + seized == original collateral",
+        );
+        kani::assert(
+            outcome.new_debt_value + repay_amount == debt_value,
+            "debt conservation: new_debt + repaid == original debt",
+        );
+
+        // Exact payout: liquidator profit is precisely the configured bonus.
+        let expected_bonus =
+            RiskManager::calculate_liquidation_bonus(repay_amount, bonus_bps).unwrap();
+        kani::assert(
+            outcome.liquidator_profit == expected_bonus,
+            "liquidator profit must exactly equal the configured discount",
+        );
+        kani::assert(
+            outcome.seized_collateral == repay_amount + outcome.liquidator_profit,
+            "seized collateral must equal repaid debt plus liquidator profit exactly",
+        );
+
+        // Resulting state must remain within valid (non-negative) bounds.
+        kani::assert(outcome.new_collateral_value >= 0, "new collateral must be non-negative");
+        kani::assert(outcome.new_debt_value >= 0, "new debt must be non-negative");
+    }
+}
+
+// ── Property 4: the *precise*, conditional health-factor invariant ─────────
+
+#[cfg(kani)]
+#[kani::proof]
+fn kani_health_factor_ratio_condition() {
+    let collateral_value: i128 = kani::any();
+    let debt_value: i128 = kani::any();
+    let repay_amount: i128 = kani::any();
+    let bonus_bps: i128 = kani::any();
+    let threshold_bps: i128 = kani::any();
+
+    kani::assume(valid_position(collateral_value, debt_value, threshold_bps));
+    // Strict inequality: a full repayment triggers `calculate_health_factor`'s
+    // `i128::MAX` short-circuit, which is trivially >= anything and verified
+    // separately in the unit tests below.
+    kani::assume(repay_amount > 0 && repay_amount < debt_value);
+    kani::assume(bonus_bps >= 0 && bonus_bps <= BPS);
+
+    let outcome =
+        match RiskManager::apply_liquidation(collateral_value, debt_value, repay_amount, bonus_bps) {
+            Ok(o) => o,
+            Err(_) => return,
+        };
+
+    let hf_before = calculate_health_factor(collateral_value, debt_value, threshold_bps);
+    let hf_after = calculate_health_factor(
+        outcome.new_collateral_value,
+        outcome.new_debt_value,
+        threshold_bps,
+    );
+
+    // The exact algebraic condition (see module docs for the derivation):
+    // collateral * repay >= debt * seized  <=>  hf_after >= hf_before.
+    let ratio_holds = match (
+        collateral_value.checked_mul(repay_amount),
+        debt_value.checked_mul(outcome.seized_collateral),
+    ) {
+        (Some(lhs), Some(rhs)) => lhs >= rhs,
+        _ => return, // proof restricted to the non-overflowing regime
+    };
+
+    if ratio_holds {
+        kani::assert(
+            hf_after >= hf_before,
+            "when collateral*repay >= debt*seized, liquidation must not worsen health factor",
+        );
+    } else {
+        // Non-strict: bps-floor-division can make both sides land on the
+        // same integer health factor right at the boundary, so this is
+        // "does not improve" rather than "strictly worsens" in general.
+        // The strict-worsening case is real and regression-pinned with a
+        // concrete example in the unit tests below.
+        kani::assert(
+            hf_after <= hf_before,
+            "when collateral*repay < debt*seized, liquidation cannot improve health factor",
+        );
+    }
+}
+
+// ── Non-kani unit/property tests (always compiled, run via `cargo test`) ────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn liquidation_bonus_never_exceeds_repay_amount() {
+        for repay in [0, 1, 1_000, 100_000, 1_000_000] {
+            for bps in [0, 500, 1_000, 5_000, 10_000] {
+                let bonus = RiskManager::calculate_liquidation_bonus(repay, bps).unwrap();
+                assert!(bonus >= 0);
+                assert!(bonus <= repay);
+            }
+        }
+    }
+
+    #[test]
+    fn apply_liquidation_conserves_collateral_and_debt() {
+        let outcome = RiskManager::apply_liquidation(100_000, 90_000, 40_000, 500).unwrap();
+        assert_eq!(outcome.new_collateral_value + outcome.seized_collateral, 100_000);
+        assert_eq!(outcome.new_debt_value + 40_000, 90_000);
+        assert_eq!(
+            outcome.seized_collateral,
+            40_000 + outcome.liquidator_profit
+        );
+    }
+
+    /// The finding documented at the top of this file: liquidation with a
+    /// bonus can *worsen* health factor for deeply under-collateralized
+    /// ("bad debt") positions. This regression-pins that exact scenario so
+    /// it can't silently regress into a false "always improves" assumption.
+    #[test]
+    fn liquidation_can_worsen_health_factor_for_bad_debt_positions() {
+        let threshold_bps = 8_000;
+        let (collateral, debt, repay, bonus_bps) = (50_000, 90_000, 40_000, 500);
+
+        let before = calculate_health_factor(collateral, debt, threshold_bps);
+        let outcome = RiskManager::apply_liquidation(collateral, debt, repay, bonus_bps).unwrap();
+        let after = calculate_health_factor(
+            outcome.new_collateral_value,
+            outcome.new_debt_value,
+            threshold_bps,
+        );
+
+        assert_eq!(before, 4_444);
+        assert_eq!(after, 1_280);
+        assert!(after < before, "expected this bad-debt scenario to worsen, not improve, HF");
+
+        // Confirm this matches the proven ratio condition: collateral*repay
+        // < debt*seized  =>  HF must decrease.
+        assert!(collateral * repay < debt * outcome.seized_collateral);
+    }
+
+    #[test]
+    fn liquidation_improves_health_factor_when_ratio_condition_holds() {
+        let threshold_bps = 8_000;
+        let (collateral, debt, repay, bonus_bps) = (100_000, 90_000, 40_000, 500);
+
+        let before = calculate_health_factor(collateral, debt, threshold_bps);
+        let outcome = RiskManager::apply_liquidation(collateral, debt, repay, bonus_bps).unwrap();
+        let after = calculate_health_factor(
+            outcome.new_collateral_value,
+            outcome.new_debt_value,
+            threshold_bps,
+        );
+
+        assert!(collateral * repay >= debt * outcome.seized_collateral);
+        assert!(after >= before);
+    }
+
+    #[test]
+    fn full_repayment_yields_max_health_factor() {
+        let outcome = RiskManager::apply_liquidation(100_000, 90_000, 90_000, 500).unwrap();
+        assert_eq!(outcome.new_debt_value, 0);
+        let hf = calculate_health_factor(outcome.new_collateral_value, outcome.new_debt_value, 8_000);
+        assert_eq!(hf, i128::MAX);
+    }
+
+    #[test]
+    fn no_overflow_at_extreme_parameters_returns_err_not_panic() {
+        assert!(RiskManager::apply_liquidation(i128::MAX, i128::MAX, i128::MAX, i128::MAX).is_err());
+        assert!(RiskManager::calculate_liquidation_bonus(i128::MAX, i128::MAX).is_err());
+    }
+}

--- a/stellar-lend/formal-verification/safe-math-proofs/Cargo.toml
+++ b/stellar-lend/formal-verification/safe-math-proofs/Cargo.toml
@@ -10,5 +10,10 @@ description = "Kani proof harnesses for the StellarLend safe-math library"
 [dependencies]
 stellarlend-safe-math = { path = "../../contracts/safe-math" }
 
-[dev-dependencies]
-kani = { version = "0.55", optional = true }
+# No `kani` crate dependency is declared here: the `cargo kani` toolchain
+# injects the `kani` crate (and the `kani` cfg) into its own sysroot
+# automatically, so listing it in Cargo.toml is unnecessary and — because
+# the real proof-harness crate isn't published to crates.io under that
+# name/version — actively breaks plain `cargo build`/`cargo test` dependency
+# resolution. All Kani-only code below is behind `#[cfg(kani)]`, which is
+# simply absent (and thus never compiled) outside `cargo kani` runs.


### PR DESCRIPTION
## Summary

Resolves the four open issues assigned to me: #458, #459, #460, #461.

**#461 — Interest rate model boundary conditions (formal verification)**
- New `stellar-lend/formal-verification/interest-rate-model-proofs` crate with Kani proof harnesses + an SMT-LIB (`z3`-verified) companion spec, plus plain `cargo test` unit/property tests that run without any extra tooling.
- Proves: `rate(0%) == base_rate`, `rate(u)` bounded above by `rate(100%)`, monotonicity, kink continuity, no overflow for realistic parameters, `0 <= supply_rate <= borrow_rate`, and a discrete-integral sanity check.
- Documents why literal "derivative continuity" at the kink isn't a real target for a two-slope model (the kink's entire purpose is an intentional slope change).

**#460 — Liquidation math invariants (formal verification)**
- New `stellar-lend/formal-verification/liquidation-math-proofs` crate (Kani + SMT-LIB, `z3`-verified).
- Adds `RiskManager::apply_liquidation` to `contracts/lending-risk`, and refactors that crate's arithmetic onto checked `stellarlend-safe-math` ops (previously raw `*`/`/`, a real overflow risk).
- **Finding surfaced by the proofs:** liquidation with a bonus can *worsen* the health factor for deeply under-collateralized positions (regression-pinned example: `collateral=50_000, debt=90_000, repay=40_000, bonus_bps=500` moves HF from `4444` to `1280`). The crate proves the exact ratio condition (`collateral*repay` vs `debt*seized`) under which liquidation improves vs. cannot improve health factor, rather than assuming the (false) unconditional claim. See the crate's README/doc comments for the full derivation.
- Also proves conservation (no value leak), exact liquidator payout, and discount bounds.

**Incidental fixes required to unblock formal verification (found while wiring up the above):**
- `stellarlend-safe-math`'s `PrecisionLoss` was missing `#[contracttype]`, breaking the crate on current soroban-sdk.
- `mul_div.rs` called `I256::rem`, which doesn't exist (`rem_euclid` does).
- `formal-verification/safe-math-proofs` (pre-existing) declared its Kani dependency as an `optional` dev-dependency (unsupported by current Cargo) pinned to a nonexistent crates.io version — fixed using the standard `cargo kani`-provides-its-own-sysroot convention, applied consistently to all three formal-verification crates.
- `lending-risk`'s dev-dependency on `test-utils` was unused and pulled in an unrelated, currently-broken crate; removed.

These three together were blocking `cargo test`/`cargo build` for every formal-verification crate in the repo, including the pre-existing `safe-math-proofs`.

**#458 — Historical interest rate tracking and analytics**
- Extends `analytics.service.ts` (which already covered historical rates/utilization/comparison/revenue/summary/export) with what was missing: rolling rate volatility (std dev over a sliding window), weighted average rates bucketed by hour/day/week/month, derived rate-change events, and `GET /api/rates/history?asset=&from=&to=&granularity=` with explicit date-range + bucket-count validation.
- `governanceActionId` on rate-change events is left `undefined` rather than fabricated — this analytics layer's rate sources (`StellarService.getPoolRateAt` etc.) are simulated with no live governance-event feed to correlate against.

**#459 — Cross-protocol ETL pipeline**
- New `services/cross-protocol-etl/` module: a standardized `StandardizedProtocolMetrics` schema, a `ProtocolAdapter` interface, a `StellarLendAdapter` (wraps the existing pool-metrics source), and a `DefiLlamaAdapter` that ingests real data from DefiLlama's public yields API (no key required) for Aave V3, Compound V3, Morpho Blue, and Spark.
- Orchestrator isolates per-adapter failures (`Promise.allSettled`) so one broken source never blocks the rest, applies data-quality checks (implausible APY/TVL/utilization filtered out with reasons recorded), and computes TVL-weighted market share.
- New endpoints: `GET /api/cross-protocol/compare`, `/market-share`, `/leaderboard`.
- DefiLlama's public endpoint only exposes supply-side APY/TVL, not borrow APY or utilization — those fields are honestly zeroed for DefiLlama-sourced rows rather than fabricated, documented in the adapter.

## Test plan
- [x] `cargo test` for both new formal-verification crates (9 + 6 tests), plus the pre-existing `safe-math-proofs` crate (now buildable) — all pass.
- [x] `z3` on both new `.smt2` specs — every safety property `unsat` (proven), reachability witness `sat` as expected.
- [x] `cargo test -p lending-risk` (11 tests) and `cargo build --workspace` for the packages in this PR's dependency chain — clean, no new warnings.
- [x] New Jest suites: `analytics.service.test.ts`, `crossProtocolEtl.service.test.ts`, `defiLlamaAdapter.test.ts` (23 tests) — all pass.
- [x] Full API suite: `npm run lint` (0 errors), `npx tsc --noEmit` (clean), `npm test` (341/341 tests pass, up from 318/318 on `main`; the pre-existing global coverage-threshold gate — already failing on `main`'s current CI — improves slightly but doesn't newly regress).

Closes #458
Closes #459
Closes #460
Closes #461
