### PR TITLE
Cross-reference duplicate perf issues #599-602

### DIFF
--- a/stellar-lend/contracts/lending/src/batch_view.rs
+++ b/stellar-lend/contracts/lending/src/batch_view.rs
@@ -1,4 +1,4 @@
-//! # Batched Multi-Pool Health Check (issue #635)
+//! # Batched Multi-Pool Health Check (issue #635, re-filed as #601)
 //!
 //! Gas-efficient batch view function that reads multiple pool positions and
 //! computes health factors in a single call, avoiding N separate cross-contract

--- a/stellar-lend/contracts/lending/src/lazy.rs
+++ b/stellar-lend/contracts/lending/src/lazy.rs
@@ -1,4 +1,4 @@
-//! # Lazy Pool-State Initialisation (issue #634)
+//! # Lazy Pool-State Initialisation (issue #634, re-filed as #600)
 //!
 //! Creating a pool previously initialised *every* state field up front, paying
 //! storage rent for slots that aren't touched until much later (or ever). This

--- a/stellar-lend/contracts/lending/src/simulation_cache.rs
+++ b/stellar-lend/contracts/lending/src/simulation_cache.rs
@@ -1,4 +1,4 @@
-//! # Transaction Simulation Cache (issue #636)
+//! # Transaction Simulation Cache (issue #636, re-filed as #602)
 //!
 //! Block-scoped LRU cache for common pool operation simulations.
 //! Identical simulation parameters within the same block reuse cached results,

--- a/stellar-lend/contracts/lending/src/storage.rs
+++ b/stellar-lend/contracts/lending/src/storage.rs
@@ -1,4 +1,4 @@
-//! # Packed Pool Configuration Storage (issue #633)
+//! # Packed Pool Configuration Storage (issue #633, re-filed as #599)
 //!
 //! Each pool-configuration parameter previously occupied its own persistent
 //! slot, so a pool paid Soroban storage rent on five-plus separate entries.


### PR DESCRIPTION
## Summary
- These four issues are exact-title duplicates of already-closed issues #633, #634, #635, #636.
- The corresponding functionality (packed pool config storage, lazy pool state initialization, batched multi-pool health check, transaction simulation cache) is already implemented and wired into the contract in `stellar-lend/contracts/lending/src/storage.rs`, `lazy.rs`, `batch_view.rs`, and `simulation_cache.rs` (see PR #657).
- This PR adds cross-reference notes in each module's doc comment pointing at the re-filed issue numbers, so the duplication is documented in-code.

closes #599,    closes #600,     closes #601,    closes #602