### PR TITLE
feat: earnings reinvestment planner (#587)

### DIFF
--- a/api/src/__tests__/reinvestment.routes.test.ts
+++ b/api/src/__tests__/reinvestment.routes.test.ts
@@ -1,0 +1,108 @@
+import request from 'supertest';
+import app from '../app';
+import { resetReinvestmentStore } from '../services/earnings/reinvestment.service';
+
+const USER = 'GA6T6URCJEEWVTUFCFBP3OONDUTFOSAFUQDIITIUU2PYNTS4YEQKGP5E';
+const POOL_A = 'GBNNVJG4O3HMCGM5C4ORI4O4H3K5CQA6OTKIW2KKWY2EEG2IL3TRXK32';
+
+describe('Reinvestment routes', () => {
+  beforeEach(() => {
+    resetReinvestmentStore();
+  });
+
+  it('supports the full create -> pause -> resume -> sweep -> history -> analytics flow', async () => {
+    const createResponse = await request(app).post('/api/reinvestment/plan').send({
+      userAddress: USER,
+      sourcePool: POOL_A,
+      strategy: 'same_pool',
+      schedule: 'real_time',
+      thresholdAmount: '100',
+    });
+    expect(createResponse.status).toBe(201);
+    expect(createResponse.body.success).toBe(true);
+    const planId = createResponse.body.plan.id;
+    expect(planId).toBeTruthy();
+
+    const getResponse = await request(app).get(`/api/reinvestment/plan/${planId}`);
+    expect(getResponse.status).toBe(200);
+    expect(getResponse.body.plan.paused).toBe(false);
+
+    const listResponse = await request(app).get(`/api/reinvestment/plans/${USER}`);
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.body.plans).toHaveLength(1);
+
+    const pauseResponse = await request(app)
+      .post(`/api/reinvestment/plan/${planId}/pause`)
+      .send({ userAddress: USER });
+    expect(pauseResponse.status).toBe(200);
+    expect(pauseResponse.body.plan.paused).toBe(true);
+
+    const blockedSweep = await request(app).post(`/api/reinvestment/plan/${planId}/sweep`).send({
+      earnedAmount: '500',
+      estimatedGasCost: '1',
+      poolPaused: false,
+    });
+    expect(blockedSweep.status).toBe(409);
+    expect(blockedSweep.body.success).toBe(false);
+
+    const resumeResponse = await request(app)
+      .post(`/api/reinvestment/plan/${planId}/resume`)
+      .send({ userAddress: USER });
+    expect(resumeResponse.status).toBe(200);
+    expect(resumeResponse.body.plan.paused).toBe(false);
+
+    const sweepResponse = await request(app).post(`/api/reinvestment/plan/${planId}/sweep`).send({
+      earnedAmount: '500',
+      estimatedGasCost: '1',
+      poolPaused: false,
+    });
+    expect(sweepResponse.status).toBe(201);
+    expect(sweepResponse.body.events).toHaveLength(1);
+    expect(sweepResponse.body.events[0].pool).toBe(POOL_A);
+
+    const historyResponse = await request(app).get(`/api/reinvestment/plan/${planId}/history`);
+    expect(historyResponse.status).toBe(200);
+    expect(historyResponse.body.history).toHaveLength(1);
+
+    const analyticsResponse = await request(app).get(`/api/reinvestment/plan/${planId}/analytics`);
+    expect(analyticsResponse.status).toBe(200);
+    expect(analyticsResponse.body.analytics.totalSweeps).toBe(1);
+  });
+
+  it('rejects plan creation with an invalid strategy', async () => {
+    const response = await request(app).post('/api/reinvestment/plan').send({
+      userAddress: USER,
+      sourcePool: POOL_A,
+      strategy: 'not_a_real_strategy',
+      schedule: 'real_time',
+      thresholdAmount: '0',
+    });
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+  });
+
+  it('returns 404 for an unknown plan id', async () => {
+    const response = await request(app).get('/api/reinvestment/plan/does-not-exist');
+    expect(response.status).toBe(404);
+    expect(response.body.success).toBe(false);
+  });
+
+  it('rejects a sweep below the configured threshold', async () => {
+    const createResponse = await request(app).post('/api/reinvestment/plan').send({
+      userAddress: USER,
+      sourcePool: POOL_A,
+      strategy: 'same_pool',
+      schedule: 'real_time',
+      thresholdAmount: '1000',
+    });
+    const planId = createResponse.body.plan.id;
+
+    const sweepResponse = await request(app).post(`/api/reinvestment/plan/${planId}/sweep`).send({
+      earnedAmount: '10',
+      estimatedGasCost: '1',
+      poolPaused: false,
+    });
+    expect(sweepResponse.status).toBe(400);
+    expect(sweepResponse.body.success).toBe(false);
+  });
+});

--- a/api/src/__tests__/reinvestment.service.test.ts
+++ b/api/src/__tests__/reinvestment.service.test.ts
@@ -1,0 +1,278 @@
+import { reinvestmentService, resetReinvestmentStore } from '../services/earnings/reinvestment.service';
+
+jest.mock('../utils/logger');
+
+const USER = 'GA6T6URCJEEWVTUFCFBP3OONDUTFOSAFUQDIITIUU2PYNTS4YEQKGP5E';
+const OTHER_USER = 'GCTC7JUZWBLSTM5N43G3EO2OE53NAIAAU7OKRQTS5XVNLWZVBVKCK5AV';
+const POOL_A = 'GBNNVJG4O3HMCGM5C4ORI4O4H3K5CQA6OTKIW2KKWY2EEG2IL3TRXK32';
+const POOL_B = 'GBBGACGJBGZDU2CXSUXLEMOJ4VU7MY3PD4Q24HUPMBXF4IV3QRGT47ZW';
+
+beforeEach(() => {
+  resetReinvestmentStore();
+});
+
+describe('reinvestmentService.createPlan()', () => {
+  it('creates a same_pool plan', () => {
+    const plan = reinvestmentService.createPlan({
+      userAddress: USER,
+      sourcePool: POOL_A,
+      strategy: 'same_pool',
+      schedule: 'real_time',
+      thresholdAmount: '100',
+    });
+    expect(plan.id).toBeTruthy();
+    expect(plan.paused).toBe(false);
+    expect(plan.totalSweeps).toBe(0);
+  });
+
+  it('rejects an invalid userAddress', () => {
+    expect(() =>
+      reinvestmentService.createPlan({
+        userAddress: 'not-an-address',
+        sourcePool: POOL_A,
+        strategy: 'same_pool',
+        schedule: 'real_time',
+        thresholdAmount: '0',
+      })
+    ).toThrow(/valid Stellar address/);
+  });
+
+  it('rejects an unknown strategy', () => {
+    expect(() =>
+      reinvestmentService.createPlan({
+        userAddress: USER,
+        sourcePool: POOL_A,
+        strategy: 'yolo' as never,
+        schedule: 'real_time',
+        thresholdAmount: '0',
+      })
+    ).toThrow(/strategy must be one of/);
+  });
+
+  it('requires weightedTargets to sum to 10000 bps for weighted strategy', () => {
+    expect(() =>
+      reinvestmentService.createPlan({
+        userAddress: USER,
+        sourcePool: POOL_A,
+        strategy: 'weighted',
+        schedule: 'real_time',
+        thresholdAmount: '0',
+        weightedTargets: [
+          { pool: POOL_A, weightBps: 5_000 },
+          { pool: POOL_B, weightBps: 4_000 },
+        ],
+      })
+    ).toThrow(/weightBps must sum to 10000/);
+  });
+
+  it('rejects weightedTargets for a non-weighted strategy', () => {
+    expect(() =>
+      reinvestmentService.createPlan({
+        userAddress: USER,
+        sourcePool: POOL_A,
+        strategy: 'same_pool',
+        schedule: 'real_time',
+        thresholdAmount: '0',
+        weightedTargets: [{ pool: POOL_A, weightBps: 10_000 }],
+      })
+    ).toThrow(/only allowed when strategy is "weighted"/);
+  });
+});
+
+describe('reinvestmentService pause/resume', () => {
+  it('pauses and resumes without touching the strategy', () => {
+    const plan = reinvestmentService.createPlan({
+      userAddress: USER,
+      sourcePool: POOL_A,
+      strategy: 'best_apy',
+      schedule: 'weekly',
+      thresholdAmount: '0',
+    });
+
+    const paused = reinvestmentService.pause(plan.id, USER);
+    expect(paused.paused).toBe(true);
+    expect(paused.strategy).toBe('best_apy');
+    expect(paused.schedule).toBe('weekly');
+
+    expect(() => reinvestmentService.pause(plan.id, USER)).toThrow(/already paused/);
+
+    const resumed = reinvestmentService.resume(plan.id, USER);
+    expect(resumed.paused).toBe(false);
+    expect(() => reinvestmentService.resume(plan.id, USER)).toThrow(/not paused/);
+  });
+
+  it('rejects pause/resume by a non-owner', () => {
+    const plan = reinvestmentService.createPlan({
+      userAddress: USER,
+      sourcePool: POOL_A,
+      strategy: 'same_pool',
+      schedule: 'real_time',
+      thresholdAmount: '0',
+    });
+    expect(() => reinvestmentService.pause(plan.id, OTHER_USER)).toThrow(/does not own/);
+  });
+
+  it('throws NotFoundError for an unknown plan id', () => {
+    expect(() => reinvestmentService.getPlan('nonexistent')).toThrow(/not found/);
+  });
+});
+
+describe('reinvestmentService.recordSweep()', () => {
+  function samePoolPlan(overrides: Partial<{ threshold: string; schedule: 'real_time' | 'daily' }> = {}) {
+    return reinvestmentService.createPlan({
+      userAddress: USER,
+      sourcePool: POOL_A,
+      strategy: 'same_pool',
+      schedule: overrides.schedule ?? 'real_time',
+      thresholdAmount: overrides.threshold ?? '100',
+    });
+  }
+
+  it('rejects a sweep below the threshold', () => {
+    const plan = samePoolPlan({ threshold: '1000' });
+    expect(() =>
+      reinvestmentService.recordSweep(plan.id, {
+        earnedAmount: '50',
+        estimatedGasCost: '1',
+        poolPaused: false,
+      })
+    ).toThrow(/below plan threshold/);
+  });
+
+  it('rejects a sweep where gas cost meets or exceeds earnings', () => {
+    const plan = samePoolPlan({ threshold: '0' });
+    expect(() =>
+      reinvestmentService.recordSweep(plan.id, {
+        earnedAmount: '100',
+        estimatedGasCost: '100',
+        poolPaused: false,
+      })
+    ).toThrow(/not economical/);
+  });
+
+  it('rejects a sweep against a paused pool', () => {
+    const plan = samePoolPlan({ threshold: '0' });
+    expect(() =>
+      reinvestmentService.recordSweep(plan.id, {
+        earnedAmount: '500',
+        estimatedGasCost: '1',
+        poolPaused: true,
+      })
+    ).toThrow(/pool is currently paused/i);
+  });
+
+  it('rejects a sweep on a paused plan', () => {
+    const plan = samePoolPlan({ threshold: '0' });
+    reinvestmentService.pause(plan.id, USER);
+    expect(() =>
+      reinvestmentService.recordSweep(plan.id, {
+        earnedAmount: '500',
+        estimatedGasCost: '1',
+        poolPaused: false,
+      })
+    ).toThrow(/plan is paused/i);
+  });
+
+  it('records a same_pool sweep and updates plan totals', () => {
+    const plan = samePoolPlan({ threshold: '0' });
+    const events = reinvestmentService.recordSweep(plan.id, {
+      earnedAmount: '500',
+      estimatedGasCost: '1',
+      poolPaused: false,
+    });
+    expect(events).toHaveLength(1);
+    expect(events[0]?.pool).toBe(POOL_A);
+    expect(events[0]?.amount).toBe('500');
+    expect(events[0]?.costBasis).toBe('500');
+
+    const updated = reinvestmentService.getPlan(plan.id);
+    expect(updated.totalReinvested).toBe('500');
+    expect(updated.totalSweeps).toBe(1);
+    expect(updated.lastSweptAt).toBeTruthy();
+  });
+
+  it('splits a weighted sweep across targets without losing dust', () => {
+    const plan = reinvestmentService.createPlan({
+      userAddress: USER,
+      sourcePool: POOL_A,
+      strategy: 'weighted',
+      schedule: 'real_time',
+      thresholdAmount: '0',
+      weightedTargets: [
+        { pool: POOL_A, weightBps: 3_333 },
+        { pool: POOL_B, weightBps: 6_667 },
+      ],
+    });
+
+    const events = reinvestmentService.recordSweep(plan.id, {
+      earnedAmount: '1000',
+      estimatedGasCost: '1',
+      poolPaused: false,
+    });
+
+    expect(events).toHaveLength(2);
+    const total = events.reduce((sum, e) => sum + BigInt(e.amount), BigInt(0));
+    expect(total.toString()).toBe('1000');
+  });
+
+  it('requires targetPool for best_apy sweeps', () => {
+    const plan = reinvestmentService.createPlan({
+      userAddress: USER,
+      sourcePool: POOL_A,
+      strategy: 'best_apy',
+      schedule: 'real_time',
+      thresholdAmount: '0',
+    });
+    expect(() =>
+      reinvestmentService.recordSweep(plan.id, {
+        earnedAmount: '500',
+        estimatedGasCost: '1',
+        poolPaused: false,
+      })
+    ).toThrow(/targetPool is required/);
+  });
+
+  it('enforces cadence for daily-scheduled plans', () => {
+    const plan = samePoolPlan({ threshold: '0', schedule: 'daily' });
+    reinvestmentService.recordSweep(plan.id, {
+      earnedAmount: '100',
+      estimatedGasCost: '1',
+      poolPaused: false,
+    });
+    expect(() =>
+      reinvestmentService.recordSweep(plan.id, {
+        earnedAmount: '100',
+        estimatedGasCost: '1',
+        poolPaused: false,
+      })
+    ).toThrow(/not eligible again until/);
+  });
+});
+
+describe('reinvestmentService.getHistory() and getAnalytics()', () => {
+  it('returns swept events newest-first and computes analytics', () => {
+    const plan = reinvestmentService.createPlan({
+      userAddress: USER,
+      sourcePool: POOL_A,
+      strategy: 'same_pool',
+      schedule: 'real_time',
+      thresholdAmount: '0',
+    });
+
+    reinvestmentService.recordSweep(plan.id, { earnedAmount: '100', estimatedGasCost: '1', poolPaused: false });
+    reinvestmentService.recordSweep(plan.id, { earnedAmount: '200', estimatedGasCost: '1', poolPaused: false });
+
+    const history = reinvestmentService.getHistory(plan.id);
+    expect(history).toHaveLength(2);
+    expect(history[0]?.amount).toBe('200'); // most recent first
+
+    const analytics = reinvestmentService.getAnalytics(plan.id, 500);
+    expect(analytics.totalSweeps).toBe(2);
+    expect(Number(analytics.compoundedValue)).toBeGreaterThanOrEqual(Number(analytics.manualValue));
+    expect(analytics.byPool[POOL_A]).toBe('300');
+  });
+
+  it('throws for analytics on an unknown plan', () => {
+    expect(() => reinvestmentService.getAnalytics('nonexistent')).toThrow(/not found/);
+  });
+});

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -57,6 +57,7 @@ import pnlRoutes from './routes/pnl.routes';
 import insuranceRoutes from './routes/insurance.routes';
 import plannerRoutes from './routes/planner.routes';
 import feeTierRoutes from './routes/fee-tiers.routes';
+import reinvestmentRoutes from './routes/reinvestment.routes';
 
 import compression from 'compression';
 import { errorHandler } from './middleware/errorHandler';
@@ -255,6 +256,7 @@ app.use('/api/pnl', pnlRoutes);
 app.use('/api/insurance', insuranceRoutes);
 app.use('/api/planner', plannerRoutes);
 app.use('/api/fee-tiers', feeTierRoutes);
+app.use('/api/reinvestment', reinvestmentRoutes);
 
 app.use(errorHandler);
 

--- a/api/src/controllers/reinvestment.controller.ts
+++ b/api/src/controllers/reinvestment.controller.ts
@@ -1,0 +1,92 @@
+import { Request, Response, NextFunction } from 'express';
+import { reinvestmentService } from '../services/earnings/reinvestment.service';
+
+export const createPlan = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const plan = reinvestmentService.createPlan(req.body);
+    return res.status(201).json({ success: true, plan });
+  } catch (err) {
+    next(err);
+    return;
+  }
+};
+
+export const getPlan = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { planId } = req.params!;
+    const plan = reinvestmentService.getPlan(planId!);
+    return res.status(200).json({ success: true, plan });
+  } catch (err) {
+    next(err);
+    return;
+  }
+};
+
+export const getUserPlans = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { userAddress } = req.params!;
+    const plans = reinvestmentService.getUserPlans(userAddress!);
+    return res.status(200).json({ success: true, plans });
+  } catch (err) {
+    next(err);
+    return;
+  }
+};
+
+export const pausePlan = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { planId } = req.params!;
+    const { userAddress } = req.body;
+    const plan = reinvestmentService.pause(planId!, userAddress);
+    return res.status(200).json({ success: true, plan });
+  } catch (err) {
+    next(err);
+    return;
+  }
+};
+
+export const resumePlan = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { planId } = req.params!;
+    const { userAddress } = req.body;
+    const plan = reinvestmentService.resume(planId!, userAddress);
+    return res.status(200).json({ success: true, plan });
+  } catch (err) {
+    next(err);
+    return;
+  }
+};
+
+export const recordSweep = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { planId } = req.params!;
+    const events = reinvestmentService.recordSweep(planId!, req.body);
+    return res.status(201).json({ success: true, events });
+  } catch (err) {
+    next(err);
+    return;
+  }
+};
+
+export const getHistory = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { planId } = req.params!;
+    const history = reinvestmentService.getHistory(planId!);
+    return res.status(200).json({ success: true, history });
+  } catch (err) {
+    next(err);
+    return;
+  }
+};
+
+export const getAnalytics = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { planId } = req.params!;
+    const apyBps = req.query.assumedApyBps ? Number(req.query.assumedApyBps) : undefined;
+    const analytics = reinvestmentService.getAnalytics(planId!, apyBps);
+    return res.status(200).json({ success: true, analytics });
+  } catch (err) {
+    next(err);
+    return;
+  }
+};

--- a/api/src/routes/reinvestment.routes.ts
+++ b/api/src/routes/reinvestment.routes.ts
@@ -1,0 +1,65 @@
+import { Router } from 'express';
+import { body, param, query } from 'express-validator';
+import * as reinvestmentController from '../controllers/reinvestment.controller';
+import { validateRequest } from '../middleware/validation';
+
+const router: Router = Router();
+
+const createPlanValidation = [
+  body('userAddress').isString().notEmpty().withMessage('userAddress is required'),
+  body('sourcePool').isString().notEmpty().withMessage('sourcePool is required'),
+  body('strategy')
+    .isIn(['same_pool', 'best_apy', 'weighted'])
+    .withMessage('strategy must be one of: same_pool, best_apy, weighted'),
+  body('schedule')
+    .isIn(['real_time', 'daily', 'weekly', 'threshold'])
+    .withMessage('schedule must be one of: real_time, daily, weekly, threshold'),
+  body('thresholdAmount').isString().notEmpty().withMessage('thresholdAmount is required'),
+  body('weightedTargets').optional().isArray().withMessage('weightedTargets must be an array'),
+];
+
+const planIdParamValidation = [param('planId').isString().notEmpty().withMessage('planId is required')];
+
+const userAddressParamValidation = [
+  param('userAddress').isString().notEmpty().withMessage('userAddress is required'),
+];
+
+const pauseResumeValidation = [
+  ...planIdParamValidation,
+  body('userAddress').isString().notEmpty().withMessage('userAddress is required'),
+];
+
+const sweepValidation = [
+  ...planIdParamValidation,
+  body('earnedAmount').isString().notEmpty().withMessage('earnedAmount is required'),
+  body('estimatedGasCost').isString().notEmpty().withMessage('estimatedGasCost is required'),
+  body('poolPaused').isBoolean().withMessage('poolPaused must be a boolean'),
+  body('targetPool').optional().isString(),
+  body('txHash').optional().isString(),
+];
+
+const analyticsValidation = [
+  ...planIdParamValidation,
+  query('assumedApyBps').optional().isInt({ min: 0, max: 10_000 }),
+];
+
+router.post('/plan', createPlanValidation, validateRequest, reinvestmentController.createPlan);
+router.get('/plan/:planId', planIdParamValidation, validateRequest, reinvestmentController.getPlan);
+router.get(
+  '/plans/:userAddress',
+  userAddressParamValidation,
+  validateRequest,
+  reinvestmentController.getUserPlans
+);
+router.post('/plan/:planId/pause', pauseResumeValidation, validateRequest, reinvestmentController.pausePlan);
+router.post('/plan/:planId/resume', pauseResumeValidation, validateRequest, reinvestmentController.resumePlan);
+router.post('/plan/:planId/sweep', sweepValidation, validateRequest, reinvestmentController.recordSweep);
+router.get('/plan/:planId/history', planIdParamValidation, validateRequest, reinvestmentController.getHistory);
+router.get(
+  '/plan/:planId/analytics',
+  analyticsValidation,
+  validateRequest,
+  reinvestmentController.getAnalytics
+);
+
+export default router;

--- a/api/src/services/earnings/reinvestment.service.ts
+++ b/api/src/services/earnings/reinvestment.service.ts
@@ -1,0 +1,299 @@
+import { randomUUID } from 'crypto';
+import { StrKey } from '@stellar/stellar-sdk';
+import logger from '../../utils/logger';
+import { ConflictError, NotFoundError, ValidationError } from '../../utils/errors';
+import {
+  CreateReinvestmentPlanRequest,
+  RecordSweepRequest,
+  ReinvestmentAnalytics,
+  ReinvestmentEvent,
+  ReinvestmentPlan,
+  ReinvestSchedule,
+  ReinvestStrategy,
+  WeightedTarget,
+} from '../../types/reinvestment';
+
+const STRATEGIES: ReinvestStrategy[] = ['same_pool', 'best_apy', 'weighted'];
+const SCHEDULES: ReinvestSchedule[] = ['real_time', 'daily', 'weekly', 'threshold'];
+const SCHEDULE_GAP_MS: Record<ReinvestSchedule, number> = {
+  real_time: 0,
+  threshold: 0,
+  daily: 24 * 60 * 60 * 1000,
+  weekly: 7 * 24 * 60 * 60 * 1000,
+};
+const BPS_DENOMINATOR = 10_000;
+const MAX_HISTORY_LEN = 200;
+const DEFAULT_ASSUMED_APY_BPS = 500; // 5%, used for compounded-vs-manual analytics when not overridden
+
+const plans = new Map<string, ReinvestmentPlan>();
+const userPlanIds = new Map<string, string[]>();
+const history = new Map<string, ReinvestmentEvent[]>();
+let nextSweepEligibleAt = new Map<string, number>();
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+function assertValidAddress(address: string, field: string): void {
+  if (!address || !StrKey.isValidEd25519PublicKey(address)) {
+    throw new ValidationError(`${field} must be a valid Stellar address`);
+  }
+}
+
+function assertPositiveAmountString(value: string, field: string): void {
+  if (!/^\d+$/.test(value)) {
+    throw new ValidationError(`${field} must be a non-negative integer string`);
+  }
+}
+
+function validateWeightedTargets(strategy: ReinvestStrategy, targets: WeightedTarget[] | undefined): WeightedTarget[] {
+  const list = targets ?? [];
+  if (strategy === 'weighted') {
+    if (list.length === 0) {
+      throw new ValidationError('weightedTargets is required when strategy is "weighted"');
+    }
+    const total = list.reduce((sum, t) => sum + t.weightBps, 0);
+    if (total !== BPS_DENOMINATOR) {
+      throw new ValidationError(`weightedTargets weightBps must sum to ${BPS_DENOMINATOR}, got ${total}`);
+    }
+    list.forEach((t, i) => assertValidAddress(t.pool, `weightedTargets[${i}].pool`));
+    return list;
+  }
+  if (list.length > 0) {
+    throw new ValidationError('weightedTargets is only allowed when strategy is "weighted"');
+  }
+  return [];
+}
+
+function appendHistory(planId: string, events: ReinvestmentEvent[]): void {
+  const existing = history.get(planId) ?? [];
+  const updated = [...events.reverse(), ...existing];
+  if (updated.length > MAX_HISTORY_LEN) {
+    updated.length = MAX_HISTORY_LEN;
+  }
+  history.set(planId, updated);
+}
+
+function requireOwnedPlan(planId: string, userAddress: string): ReinvestmentPlan {
+  const plan = plans.get(planId);
+  if (!plan) throw new NotFoundError(`Reinvestment plan ${planId} not found`);
+  if (plan.userAddress !== userAddress) {
+    throw new ValidationError('userAddress does not own this reinvestment plan');
+  }
+  return plan;
+}
+
+function finalizeSweep(
+  plan: ReinvestmentPlan,
+  events: ReinvestmentEvent[],
+  scheduleGapMs: number
+): ReinvestmentEvent[] {
+  const totalSwept = events.reduce((sum, e) => sum + BigInt(e.amount), BigInt(0));
+  const updated: ReinvestmentPlan = {
+    ...plan,
+    totalReinvested: (BigInt(plan.totalReinvested) + totalSwept).toString(),
+    totalSweeps: plan.totalSweeps + 1,
+    lastSweptAt: now(),
+    updatedAt: now(),
+  };
+  plans.set(plan.id, updated);
+  appendHistory(plan.id, events);
+  if (scheduleGapMs > 0) {
+    nextSweepEligibleAt.set(plan.id, Date.now() + scheduleGapMs);
+  }
+  logger.info(`Reinvestment sweep recorded: ${plan.id}, events: ${events.length}, total: ${totalSwept.toString()}`);
+  return events;
+}
+
+export const reinvestmentService = {
+  createPlan(input: CreateReinvestmentPlanRequest): ReinvestmentPlan {
+    assertValidAddress(input.userAddress, 'userAddress');
+    assertValidAddress(input.sourcePool, 'sourcePool');
+    if (!STRATEGIES.includes(input.strategy)) {
+      throw new ValidationError(`strategy must be one of: ${STRATEGIES.join(', ')}`);
+    }
+    if (!SCHEDULES.includes(input.schedule)) {
+      throw new ValidationError(`schedule must be one of: ${SCHEDULES.join(', ')}`);
+    }
+    assertPositiveAmountString(input.thresholdAmount, 'thresholdAmount');
+    const weightedTargets = validateWeightedTargets(input.strategy, input.weightedTargets);
+
+    const timestamp = now();
+    const plan: ReinvestmentPlan = {
+      id: randomUUID(),
+      userAddress: input.userAddress,
+      sourcePool: input.sourcePool,
+      strategy: input.strategy,
+      schedule: input.schedule,
+      thresholdAmount: input.thresholdAmount,
+      weightedTargets,
+      paused: false,
+      totalReinvested: '0',
+      totalSweeps: 0,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    };
+
+    plans.set(plan.id, plan);
+    const existing = userPlanIds.get(input.userAddress) ?? [];
+    existing.push(plan.id);
+    userPlanIds.set(input.userAddress, existing);
+
+    logger.info(`Reinvestment plan created: ${plan.id} for ${input.userAddress}`);
+    return plan;
+  },
+
+  getPlan(planId: string): ReinvestmentPlan {
+    const plan = plans.get(planId);
+    if (!plan) throw new NotFoundError(`Reinvestment plan ${planId} not found`);
+    return plan;
+  },
+
+  getUserPlans(userAddress: string): ReinvestmentPlan[] {
+    const ids = userPlanIds.get(userAddress) ?? [];
+    return ids.map((id) => plans.get(id)).filter((p): p is ReinvestmentPlan => Boolean(p));
+  },
+
+  pause(planId: string, userAddress: string): ReinvestmentPlan {
+    const plan = requireOwnedPlan(planId, userAddress);
+    if (plan.paused) throw new ConflictError('Reinvestment plan is already paused');
+    const updated: ReinvestmentPlan = { ...plan, paused: true, updatedAt: now() };
+    plans.set(planId, updated);
+    logger.info(`Reinvestment plan paused: ${planId}`);
+    return updated;
+  },
+
+  resume(planId: string, userAddress: string): ReinvestmentPlan {
+    const plan = requireOwnedPlan(planId, userAddress);
+    if (!plan.paused) throw new ConflictError('Reinvestment plan is not paused');
+    const updated: ReinvestmentPlan = { ...plan, paused: false, updatedAt: now() };
+    plans.set(planId, updated);
+    logger.info(`Reinvestment plan resumed: ${planId}`);
+    return updated;
+  },
+
+  /**
+   * Record a sweep that has already been executed on-chain (via the earnings-reinvest
+   * contract's `sweep` call). Applies the same gating rules as the contract — threshold,
+   * pause state, pool-paused state, gas-vs-earnings viability, and schedule cadence — so
+   * API consumers get a consistent error before/without submitting a doomed transaction,
+   * and records the resulting reinvestment event(s) for history/analytics.
+   */
+  recordSweep(planId: string, input: RecordSweepRequest): ReinvestmentEvent[] {
+    const plan = plans.get(planId);
+    if (!plan) throw new NotFoundError(`Reinvestment plan ${planId} not found`);
+    if (plan.paused) throw new ConflictError('Reinvestment plan is paused');
+    if (input.poolPaused) throw new ConflictError('Target pool is currently paused');
+
+    assertPositiveAmountString(input.earnedAmount, 'earnedAmount');
+    assertPositiveAmountString(input.estimatedGasCost, 'estimatedGasCost');
+    const earned = BigInt(input.earnedAmount);
+    const gasCost = BigInt(input.estimatedGasCost);
+    const threshold = BigInt(plan.thresholdAmount);
+
+    if (earned < threshold) {
+      throw new ValidationError(
+        `earnedAmount (${input.earnedAmount}) is below plan threshold (${plan.thresholdAmount})`
+      );
+    }
+    if (gasCost >= earned) {
+      throw new ValidationError('estimatedGasCost meets or exceeds earnedAmount; sweep is not economical');
+    }
+
+    const gap = SCHEDULE_GAP_MS[plan.schedule];
+    if (gap > 0) {
+      const eligibleAt = nextSweepEligibleAt.get(planId) ?? 0;
+      if (Date.now() < eligibleAt) {
+        throw new ConflictError(
+          `Plan is on a ${plan.schedule} schedule; not eligible again until ${new Date(eligibleAt).toISOString()}`
+        );
+      }
+    }
+
+    if (plan.strategy === 'weighted') {
+      let allocated = BigInt(0);
+      const events: ReinvestmentEvent[] = [];
+      plan.weightedTargets.forEach((target, i) => {
+        const isLast = i === plan.weightedTargets.length - 1;
+        const share = isLast
+          ? earned - allocated
+          : (earned * BigInt(target.weightBps)) / BigInt(BPS_DENOMINATOR);
+        allocated += share;
+        events.push({
+          planId,
+          pool: target.pool,
+          amount: share.toString(),
+          costBasis: share.toString(),
+          sweptAt: now(),
+          txHash: input.txHash,
+        });
+      });
+      return finalizeSweep(plan, events, gap);
+    }
+
+    let pool = plan.sourcePool;
+    if (plan.strategy === 'best_apy') {
+      if (!input.targetPool) {
+        throw new ValidationError('targetPool is required for the "best_apy" strategy');
+      }
+      assertValidAddress(input.targetPool, 'targetPool');
+      pool = input.targetPool;
+    }
+    const event: ReinvestmentEvent = {
+      planId,
+      pool,
+      amount: earned.toString(),
+      costBasis: earned.toString(),
+      sweptAt: now(),
+      txHash: input.txHash,
+    };
+    return finalizeSweep(plan, [event], gap);
+  },
+
+  getHistory(planId: string): ReinvestmentEvent[] {
+    if (!plans.has(planId)) throw new NotFoundError(`Reinvestment plan ${planId} not found`);
+    return [...(history.get(planId) ?? [])];
+  },
+
+  getAnalytics(planId: string, assumedApyBps: number = DEFAULT_ASSUMED_APY_BPS): ReinvestmentAnalytics {
+    const plan = plans.get(planId);
+    if (!plan) throw new NotFoundError(`Reinvestment plan ${planId} not found`);
+    if (assumedApyBps < 0 || assumedApyBps > BPS_DENOMINATOR) {
+      throw new ValidationError('assumedApyBps must be between 0 and 10000');
+    }
+
+    const events = history.get(planId) ?? [];
+    const dailyRate = assumedApyBps / BPS_DENOMINATOR / 365;
+    const nowMs = Date.now();
+
+    let compoundedValue = 0;
+    let manualValue = 0;
+    const byPool: Record<string, string> = {};
+
+    for (const event of events) {
+      const amount = Number(event.amount);
+      manualValue += amount;
+      const daysElapsed = Math.max(0, (nowMs - new Date(event.sweptAt).getTime()) / (24 * 60 * 60 * 1000));
+      compoundedValue += amount * Math.pow(1 + dailyRate, daysElapsed);
+      byPool[event.pool] = ((BigInt(byPool[event.pool] ?? '0')) + BigInt(event.amount)).toString();
+    }
+
+    return {
+      planId,
+      totalReinvested: plan.totalReinvested,
+      totalSweeps: plan.totalSweeps,
+      compoundedValue: compoundedValue.toFixed(0),
+      manualValue: manualValue.toFixed(0),
+      additionalYieldFromCompounding: (compoundedValue - manualValue).toFixed(0),
+      assumedApyBps,
+      byPool,
+    };
+  },
+};
+
+export function resetReinvestmentStore(): void {
+  plans.clear();
+  userPlanIds.clear();
+  history.clear();
+  nextSweepEligibleAt = new Map<string, number>();
+}

--- a/api/src/services/migration.service.ts
+++ b/api/src/services/migration.service.ts
@@ -1,8 +1,7 @@
 import { StellarService } from './stellar.service';
 import { redisCacheService } from './redisCache.service';
-import { Logger } from '../utils/logger';
+import logger from '../utils/logger';
 
-const logger = new Logger('MigrationService');
 const MIGRATION_CACHE_TTL_S = 60;
 
 export interface MigrationPreview {

--- a/api/src/services/risk-engine/stress-tester/stress-test.service.ts
+++ b/api/src/services/risk-engine/stress-tester/stress-test.service.ts
@@ -1,6 +1,6 @@
-import { StressTestInput, StressTestResult, PositionSnapshot } from '../risk-engine/stress-tester/types';
-import { stressTester } from '../risk-engine/stress-tester/engine';
-import { scenarioRegistry } from '../risk-engine/stress-tester/scenario-registry';
+import { StressTestInput, StressTestResult, PositionSnapshot } from './types';
+import { stressTester } from './engine';
+import { scenarioRegistry } from './scenario-registry';
 
 class StressTestService {
   runStressTest(input: StressTestInput): StressTestResult {

--- a/api/src/types/reinvestment.ts
+++ b/api/src/types/reinvestment.ts
@@ -1,0 +1,67 @@
+export type ReinvestStrategy = 'same_pool' | 'best_apy' | 'weighted';
+
+export type ReinvestSchedule = 'real_time' | 'daily' | 'weekly' | 'threshold';
+
+export interface WeightedTarget {
+  pool: string;
+  weightBps: number;
+}
+
+export interface ReinvestmentPlan {
+  id: string;
+  userAddress: string;
+  sourcePool: string;
+  strategy: ReinvestStrategy;
+  schedule: ReinvestSchedule;
+  /** Minimum earned amount (in the pool's asset base units) required before a sweep executes. */
+  thresholdAmount: string;
+  /** Only populated when strategy === 'weighted'; weightBps values must sum to 10000. */
+  weightedTargets: WeightedTarget[];
+  paused: boolean;
+  totalReinvested: string;
+  totalSweeps: number;
+  createdAt: string;
+  updatedAt: string;
+  lastSweptAt?: string;
+}
+
+export interface CreateReinvestmentPlanRequest {
+  userAddress: string;
+  sourcePool: string;
+  strategy: ReinvestStrategy;
+  schedule: ReinvestSchedule;
+  thresholdAmount: string;
+  weightedTargets?: WeightedTarget[];
+}
+
+export interface RecordSweepRequest {
+  /** Resolved target pool for 'same_pool' / 'best_apy' strategies; ignored for 'weighted'. */
+  targetPool?: string;
+  earnedAmount: string;
+  poolPaused: boolean;
+  estimatedGasCost: string;
+  txHash?: string;
+}
+
+export interface ReinvestmentEvent {
+  planId: string;
+  pool: string;
+  amount: string;
+  /** Cost basis recorded for this reinvestment lot, for external tax-lot accounting. */
+  costBasis: string;
+  sweptAt: string;
+  txHash?: string;
+}
+
+export interface ReinvestmentAnalytics {
+  planId: string;
+  totalReinvested: string;
+  totalSweeps: number;
+  /** Projected value of reinvested amounts compounding at assumedApyBps since each sweep. */
+  compoundedValue: string;
+  /** Same amounts with no reinvestment (manual sweep, held idle). */
+  manualValue: string;
+  additionalYieldFromCompounding: string;
+  assumedApyBps: number;
+  byPool: Record<string, string>;
+}

--- a/stellar-lend/Cargo.lock
+++ b/stellar-lend/Cargo.lock
@@ -39,6 +39,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -252,6 +261,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,6 +303,12 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 
 [[package]]
 name = "byteorder"
@@ -785,6 +815,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -805,6 +841,13 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flash-loan-liquidation-tests"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
 
 [[package]]
 name = "fnv"
@@ -1339,6 +1382,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e04e2fd2b8188ea827b32ef11de88377086d690286ab35747ef7f9bf3ccb590"
 
 [[package]]
+name = "insurance-marketplace"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1514,6 +1564,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "liquidation-strategy"
 version = "0.1.0"
 dependencies = [
@@ -1568,6 +1624,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f607c237553f086e7043417a51df26b2eb899d3caff94e6a67592ff992fedc7"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1610,6 +1676,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "multi-user-simulation"
+version = "0.1.0"
+dependencies = [
+ "rand 0.8.5",
+ "soroban-sdk",
+ "statrs",
+ "tokio",
+]
+
+[[package]]
+name = "nalgebra"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d506eb7e08d6329505faa8a3a00a5dcc6de9f76e0c77e4b75763ae3c770831ff"
+dependencies = [
+ "approx",
+ "matrixmultiply",
+ "nalgebra-macros",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "rand 0.8.5",
+ "rand_distr",
+ "simba",
+ "typenum",
+]
+
+[[package]]
+name = "nalgebra-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01fcc0b8149b4632adc89ac3b7b31a12fb6099a0317a4eb2ebff574ef7de7218"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1625,6 +1730,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
  "num-traits",
 ]
 
@@ -1655,12 +1769,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1858,13 +1983,24 @@ version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
+ "bit-set",
+ "bit-vec",
  "bitflags",
  "num-traits",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
  "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
  "unarray",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
@@ -1997,6 +2133,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2004,6 +2150,12 @@ checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
  "rand_core 0.9.5",
 ]
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "redox_syscall"
@@ -2149,6 +2301,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2230,10 +2395,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "same-file"
@@ -2454,6 +2640,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "shared-math"
+version = "0.1.0"
+dependencies = [
+ "proptest",
+ "soroban-sdk",
+]
+
+[[package]]
+name = "shared-storage"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2477,6 +2678,19 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "simba"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0b7840f121a46d63066ee7a99fc81dcabbc6105e437cae43528cea199b5a05f"
+dependencies = [
+ "approx",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "wide",
 ]
 
 [[package]]
@@ -2745,6 +2959,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "statrs"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b35a062dbadac17a42e0fc64c27f419b25d6fae98572eb43c8814c9e873d7721"
+dependencies = [
+ "approx",
+ "lazy_static",
+ "nalgebra",
+ "num-traits",
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "stealth-address"
 version = "0.1.0"
 dependencies = [
@@ -2924,6 +3151,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "stellarlend-earnings-reinvest"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "stellarlend-institutional-wallet"
 version = "0.1.0"
 dependencies = [
@@ -3100,6 +3334,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3516,6 +3763,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3681,6 +3937,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]

--- a/stellar-lend/Cargo.toml
+++ b/stellar-lend/Cargo.toml
@@ -54,6 +54,7 @@ members = [
   "contracts/debt-token",
   "contracts/shared-math",
   "contracts/shared-storage",
+  "contracts/earnings-reinvest",
   "tests/simulation/multi-user",
   "tests/integration/flash-loan-liquidation",
 ]

--- a/stellar-lend/contracts/earnings-reinvest/Cargo.toml
+++ b/stellar-lend/contracts/earnings-reinvest/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "stellarlend-earnings-reinvest"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+name = "stellarlend_earnings_reinvest"
+crate-type = ["cdylib", "rlib"]
+path = "src/lib.rs"
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+
+[features]
+testutils = ["soroban-sdk/testutils"]

--- a/stellar-lend/contracts/earnings-reinvest/src/lib.rs
+++ b/stellar-lend/contracts/earnings-reinvest/src/lib.rs
@@ -1,0 +1,417 @@
+#![no_std]
+
+//! Earnings reinvestment planner.
+//!
+//! Lets a lender configure a strategy for automatically routing earned
+//! interest back into lending pools instead of letting it sit idle. The
+//! actual pool-selection logic for the `BestApy` strategy (comparing APYs
+//! across pools) is resolved off-chain by the caller and passed in via
+//! `target_pool` — this contract focuses on plan state, schedule/threshold
+//! gating, and recording reinvestment events for cost-basis tracking.
+
+use soroban_sdk::{contract, contracterror, contractevent, contractimpl, contracttype, Address, Env, Vec};
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum ReinvestError {
+    NotInitialized = 1,
+    AlreadyInitialized = 2,
+    Unauthorized = 3,
+    PlanNotFound = 4,
+    InvalidThreshold = 5,
+    InvalidWeights = 6,
+    PlanPaused = 7,
+    PlanNotPaused = 8,
+    BelowThreshold = 9,
+    PoolPaused = 10,
+    GasExceedsEarnings = 11,
+    ScheduleNotDue = 12,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[repr(u32)]
+pub enum ReinvestStrategy {
+    SamePool = 0,
+    BestApy = 1,
+    Weighted = 2,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[repr(u32)]
+pub enum ReinvestSchedule {
+    RealTime = 0,
+    Daily = 1,
+    Weekly = 2,
+    Threshold = 3,
+}
+
+/// One target pool + share (in basis points, must sum to 10_000 across a plan) for the Weighted strategy.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WeightedTarget {
+    pub pool: Address,
+    pub weight_bps: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct ReinvestPlan {
+    pub id: u64,
+    pub owner: Address,
+    pub source_pool: Address,
+    pub strategy: ReinvestStrategy,
+    pub schedule: ReinvestSchedule,
+    /// Minimum earned amount required before a sweep executes.
+    pub threshold: i128,
+    /// Only populated (and used) when `strategy == Weighted`.
+    pub weighted_targets: Vec<WeightedTarget>,
+    pub paused: bool,
+    pub total_reinvested: i128,
+    pub total_sweeps: u32,
+    pub created_at: u64,
+    pub last_swept_at: u64,
+    /// Earliest ledger a Daily/Weekly-scheduled sweep may execute again; unused for RealTime/Threshold.
+    pub next_eligible_ledger: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct ReinvestEvent {
+    pub plan_id: u64,
+    pub pool: Address,
+    pub amount: i128,
+    /// Cost basis recorded for this reinvestment lot (equal to `amount` at time of reinvestment).
+    pub cost_basis: i128,
+    pub swept_at: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub enum DataKey {
+    Admin,
+    NextId,
+    Plan(u64),
+    UserPlans(Address),
+    History(u64),
+}
+
+const DAY_LEDGERS: u64 = 17_280;
+const WEEK_LEDGERS: u64 = DAY_LEDGERS * 7;
+const MAX_HISTORY_LEN: u32 = 50;
+const BPS_DENOMINATOR: u32 = 10_000;
+
+#[contractevent]
+#[derive(Clone)]
+pub struct PlanCreatedEvent {
+    #[topic]
+    pub plan_id: u64,
+    #[topic]
+    pub owner: Address,
+}
+
+#[contractevent]
+#[derive(Clone)]
+pub struct SweptEvent {
+    #[topic]
+    pub plan_id: u64,
+    pub earned: i128,
+    pub event_count: u32,
+}
+
+#[contract]
+pub struct EarningsReinvestContract;
+
+#[contractimpl]
+impl EarningsReinvestContract {
+    pub fn initialize(env: Env, admin: Address) -> Result<(), ReinvestError> {
+        if env.storage().instance().has(&DataKey::Admin) {
+            return Err(ReinvestError::AlreadyInitialized);
+        }
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::NextId, &1u64);
+        Ok(())
+    }
+
+    /// Create a reinvestment plan for `owner`, sourced from `source_pool`.
+    ///
+    /// `weighted_targets` is only validated/used when `strategy == Weighted`, in which case
+    /// its `weight_bps` values must sum to exactly 10_000 (100%).
+    pub fn create_plan(
+        env: Env,
+        owner: Address,
+        source_pool: Address,
+        strategy: ReinvestStrategy,
+        schedule: ReinvestSchedule,
+        threshold: i128,
+        weighted_targets: Vec<WeightedTarget>,
+    ) -> Result<u64, ReinvestError> {
+        owner.require_auth();
+        Self::require_initialized(&env)?;
+
+        if threshold < 0 {
+            return Err(ReinvestError::InvalidThreshold);
+        }
+
+        if strategy == ReinvestStrategy::Weighted {
+            if weighted_targets.is_empty() {
+                return Err(ReinvestError::InvalidWeights);
+            }
+            let mut total_bps: u32 = 0;
+            for target in weighted_targets.iter() {
+                total_bps = total_bps
+                    .checked_add(target.weight_bps)
+                    .ok_or(ReinvestError::InvalidWeights)?;
+            }
+            if total_bps != BPS_DENOMINATOR {
+                return Err(ReinvestError::InvalidWeights);
+            }
+        } else if !weighted_targets.is_empty() {
+            return Err(ReinvestError::InvalidWeights);
+        }
+
+        let plan_id = Self::next_id(&env);
+        let current_ledger = env.ledger().sequence() as u64;
+
+        let plan = ReinvestPlan {
+            id: plan_id,
+            owner: owner.clone(),
+            source_pool,
+            strategy,
+            schedule,
+            threshold,
+            weighted_targets,
+            paused: false,
+            total_reinvested: 0,
+            total_sweeps: 0,
+            created_at: current_ledger,
+            last_swept_at: 0,
+            next_eligible_ledger: 0,
+        };
+
+        env.storage().persistent().set(&DataKey::Plan(plan_id), &plan);
+
+        let mut user_plans = Self::get_user_plans_internal(&env, &owner);
+        user_plans.push_back(plan_id);
+        env.storage()
+            .persistent()
+            .set(&DataKey::UserPlans(owner.clone()), &user_plans);
+
+        PlanCreatedEvent { plan_id, owner }.publish(&env);
+
+        Ok(plan_id)
+    }
+
+    /// Sweep earned interest into the plan's target pool(s), subject to pause state, the
+    /// plan's threshold, schedule cadence, pool-paused state, and gas-vs-earnings viability.
+    ///
+    /// `target_pool` is the resolved best-APY pool when `strategy == BestApy` (ignored otherwise).
+    /// `pool_paused` and `estimated_gas_cost` are supplied by the caller (an off-chain keeper),
+    /// since this contract does not itself cross-call into lending pools.
+    pub fn sweep(
+        env: Env,
+        keeper: Address,
+        plan_id: u64,
+        target_pool: Address,
+        earned: i128,
+        pool_paused: bool,
+        estimated_gas_cost: i128,
+    ) -> Result<Vec<ReinvestEvent>, ReinvestError> {
+        keeper.require_auth();
+
+        let mut plan: ReinvestPlan = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Plan(plan_id))
+            .ok_or(ReinvestError::PlanNotFound)?;
+
+        if plan.paused {
+            return Err(ReinvestError::PlanPaused);
+        }
+        if pool_paused {
+            return Err(ReinvestError::PoolPaused);
+        }
+        if earned < plan.threshold {
+            return Err(ReinvestError::BelowThreshold);
+        }
+        if estimated_gas_cost >= earned {
+            return Err(ReinvestError::GasExceedsEarnings);
+        }
+
+        let current_ledger = env.ledger().sequence() as u64;
+        let schedule_gap = Self::schedule_gap_ledgers(&plan.schedule);
+        if schedule_gap > 0 && current_ledger < plan.next_eligible_ledger {
+            return Err(ReinvestError::ScheduleNotDue);
+        }
+
+        let events = Self::build_events(&env, &plan, &target_pool, earned, current_ledger);
+
+        plan.total_reinvested += earned;
+        plan.total_sweeps += 1;
+        plan.last_swept_at = current_ledger;
+        if schedule_gap > 0 {
+            plan.next_eligible_ledger = current_ledger + schedule_gap;
+        }
+        env.storage().persistent().set(&DataKey::Plan(plan_id), &plan);
+
+        Self::append_history(&env, plan_id, &events);
+
+        SweptEvent {
+            plan_id,
+            earned,
+            event_count: events.len(),
+        }
+        .publish(&env);
+
+        Ok(events)
+    }
+
+    pub fn pause(env: Env, owner: Address, plan_id: u64) -> Result<(), ReinvestError> {
+        let mut plan = Self::load_owned_plan(&env, &owner, plan_id)?;
+        if plan.paused {
+            return Err(ReinvestError::PlanPaused);
+        }
+        plan.paused = true;
+        env.storage().persistent().set(&DataKey::Plan(plan_id), &plan);
+        Ok(())
+    }
+
+    pub fn resume(env: Env, owner: Address, plan_id: u64) -> Result<(), ReinvestError> {
+        let mut plan = Self::load_owned_plan(&env, &owner, plan_id)?;
+        if !plan.paused {
+            return Err(ReinvestError::PlanNotPaused);
+        }
+        plan.paused = false;
+        env.storage().persistent().set(&DataKey::Plan(plan_id), &plan);
+        Ok(())
+    }
+
+    pub fn get_plan(env: Env, plan_id: u64) -> Option<ReinvestPlan> {
+        env.storage().persistent().get(&DataKey::Plan(plan_id))
+    }
+
+    pub fn get_user_plans(env: Env, owner: Address) -> Vec<u64> {
+        Self::get_user_plans_internal(&env, &owner)
+    }
+
+    pub fn get_history(env: Env, plan_id: u64) -> Vec<ReinvestEvent> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::History(plan_id))
+            .unwrap_or_else(|| Vec::new(&env))
+    }
+
+    fn load_owned_plan(env: &Env, owner: &Address, plan_id: u64) -> Result<ReinvestPlan, ReinvestError> {
+        owner.require_auth();
+        let plan: ReinvestPlan = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Plan(plan_id))
+            .ok_or(ReinvestError::PlanNotFound)?;
+        if &plan.owner != owner {
+            return Err(ReinvestError::Unauthorized);
+        }
+        Ok(plan)
+    }
+
+    fn build_events(
+        env: &Env,
+        plan: &ReinvestPlan,
+        target_pool: &Address,
+        earned: i128,
+        current_ledger: u64,
+    ) -> Vec<ReinvestEvent> {
+        let mut events = Vec::new(env);
+        match plan.strategy {
+            ReinvestStrategy::SamePool => {
+                events.push_back(ReinvestEvent {
+                    plan_id: plan.id,
+                    pool: plan.source_pool.clone(),
+                    amount: earned,
+                    cost_basis: earned,
+                    swept_at: current_ledger,
+                });
+            }
+            ReinvestStrategy::BestApy => {
+                events.push_back(ReinvestEvent {
+                    plan_id: plan.id,
+                    pool: target_pool.clone(),
+                    amount: earned,
+                    cost_basis: earned,
+                    swept_at: current_ledger,
+                });
+            }
+            ReinvestStrategy::Weighted => {
+                let count = plan.weighted_targets.len();
+                let mut allocated: i128 = 0;
+                for (i, target) in plan.weighted_targets.iter().enumerate() {
+                    let share = if i as u32 == count - 1 {
+                        // Last target absorbs any rounding remainder so the full
+                        // `earned` amount is always accounted for (no dust lost).
+                        earned - allocated
+                    } else {
+                        earned * (target.weight_bps as i128) / (BPS_DENOMINATOR as i128)
+                    };
+                    allocated += share;
+                    events.push_back(ReinvestEvent {
+                        plan_id: plan.id,
+                        pool: target.pool.clone(),
+                        amount: share,
+                        cost_basis: share,
+                        swept_at: current_ledger,
+                    });
+                }
+            }
+        }
+        events
+    }
+
+    fn append_history(env: &Env, plan_id: u64, new_events: &Vec<ReinvestEvent>) {
+        let mut history: Vec<ReinvestEvent> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::History(plan_id))
+            .unwrap_or_else(|| Vec::new(env));
+        for event in new_events.iter() {
+            if history.len() >= MAX_HISTORY_LEN {
+                history.remove(0);
+            }
+            history.push_back(event);
+        }
+        env.storage().persistent().set(&DataKey::History(plan_id), &history);
+    }
+
+    fn require_initialized(env: &Env) -> Result<(), ReinvestError> {
+        if !env.storage().instance().has(&DataKey::Admin) {
+            return Err(ReinvestError::NotInitialized);
+        }
+        Ok(())
+    }
+
+    fn next_id(env: &Env) -> u64 {
+        let id: u64 = env.storage().instance().get(&DataKey::NextId).unwrap_or(1);
+        env.storage().instance().set(&DataKey::NextId, &(id + 1));
+        id
+    }
+
+    fn schedule_gap_ledgers(schedule: &ReinvestSchedule) -> u64 {
+        match schedule {
+            ReinvestSchedule::RealTime | ReinvestSchedule::Threshold => 0,
+            ReinvestSchedule::Daily => DAY_LEDGERS,
+            ReinvestSchedule::Weekly => WEEK_LEDGERS,
+        }
+    }
+
+    fn get_user_plans_internal(env: &Env, owner: &Address) -> Vec<u64> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::UserPlans(owner.clone()))
+            .unwrap_or_else(|| Vec::new(env))
+    }
+}
+
+#[cfg(test)]
+mod lib_test;

--- a/stellar-lend/contracts/earnings-reinvest/src/lib_test.rs
+++ b/stellar-lend/contracts/earnings-reinvest/src/lib_test.rs
@@ -1,0 +1,275 @@
+#![cfg(test)]
+
+use soroban_sdk::{testutils::Address as _, testutils::Ledger, Address, Env, Vec};
+
+use crate::{
+    EarningsReinvestContract, EarningsReinvestContractClient, ReinvestError, ReinvestSchedule,
+    ReinvestStrategy, WeightedTarget,
+};
+
+fn setup() -> (Env, Address, Address, Address, EarningsReinvestContractClient<'static>) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let owner = Address::generate(&env);
+    let pool = Address::generate(&env);
+    let contract_id = env.register(EarningsReinvestContract, ());
+    let client = EarningsReinvestContractClient::new(&env, &contract_id);
+    client.initialize(&admin);
+    (env, admin, owner, pool, client)
+}
+
+#[test]
+fn test_initialize_cannot_double_init() {
+    let (_, admin, _, _, client) = setup();
+    let result = client.try_initialize(&admin);
+    assert_eq!(result.unwrap_err().unwrap(), ReinvestError::AlreadyInitialized);
+}
+
+#[test]
+fn test_create_plan_same_pool() {
+    let (env, _, owner, pool, client) = setup();
+    let plan_id = client.create_plan(
+        &owner,
+        &pool,
+        &ReinvestStrategy::SamePool,
+        &ReinvestSchedule::RealTime,
+        &100,
+        &Vec::new(&env),
+    );
+    let plan = client.get_plan(&plan_id).unwrap();
+    assert_eq!(plan.owner, owner);
+    assert_eq!(plan.source_pool, pool);
+    assert_eq!(plan.threshold, 100);
+    assert!(!plan.paused);
+}
+
+#[test]
+fn test_create_plan_weighted_requires_full_bps() {
+    let (env, _, owner, pool, client) = setup();
+    let pool_b = Address::generate(&env);
+    let mut targets = Vec::new(&env);
+    targets.push_back(WeightedTarget { pool: pool.clone(), weight_bps: 6_000 });
+    targets.push_back(WeightedTarget { pool: pool_b, weight_bps: 3_000 });
+
+    let result = client.try_create_plan(
+        &owner,
+        &pool,
+        &ReinvestStrategy::Weighted,
+        &ReinvestSchedule::RealTime,
+        &0,
+        &targets,
+    );
+    assert_eq!(result.unwrap_err().unwrap(), ReinvestError::InvalidWeights);
+}
+
+#[test]
+fn test_create_plan_rejects_weighted_targets_for_same_pool_strategy() {
+    let (env, _, owner, pool, client) = setup();
+    let mut targets = Vec::new(&env);
+    targets.push_back(WeightedTarget { pool: pool.clone(), weight_bps: 10_000 });
+
+    let result = client.try_create_plan(
+        &owner,
+        &pool,
+        &ReinvestStrategy::SamePool,
+        &ReinvestSchedule::RealTime,
+        &0,
+        &targets,
+    );
+    assert_eq!(result.unwrap_err().unwrap(), ReinvestError::InvalidWeights);
+}
+
+#[test]
+fn test_sweep_same_pool_success() {
+    let (env, _, owner, pool, client) = setup();
+    let keeper = Address::generate(&env);
+    let plan_id = client.create_plan(
+        &owner,
+        &pool,
+        &ReinvestStrategy::SamePool,
+        &ReinvestSchedule::RealTime,
+        &100,
+        &Vec::new(&env),
+    );
+
+    let events = client.sweep(&keeper, &plan_id, &pool, &500, &false, &10);
+    assert_eq!(events.len(), 1);
+    let event = events.get(0).unwrap();
+    assert_eq!(event.pool, pool);
+    assert_eq!(event.amount, 500);
+    assert_eq!(event.cost_basis, 500);
+
+    let plan = client.get_plan(&plan_id).unwrap();
+    assert_eq!(plan.total_reinvested, 500);
+    assert_eq!(plan.total_sweeps, 1);
+
+    let history = client.get_history(&plan_id);
+    assert_eq!(history.len(), 1);
+}
+
+#[test]
+fn test_sweep_weighted_split_covers_full_amount() {
+    let (env, _, owner, pool_a, client) = setup();
+    let keeper = Address::generate(&env);
+    let pool_b = Address::generate(&env);
+    let mut targets = Vec::new(&env);
+    targets.push_back(WeightedTarget { pool: pool_a.clone(), weight_bps: 3_333 });
+    targets.push_back(WeightedTarget { pool: pool_b.clone(), weight_bps: 6_667 });
+
+    let plan_id = client.create_plan(
+        &owner,
+        &pool_a,
+        &ReinvestStrategy::Weighted,
+        &ReinvestSchedule::RealTime,
+        &0,
+        &targets,
+    );
+
+    let events = client.sweep(&keeper, &plan_id, &pool_a, &1_000, &false, &1);
+    assert_eq!(events.len(), 2);
+    let total: i128 = events.iter().map(|e| e.amount).sum();
+    assert_eq!(total, 1_000); // no dust lost to rounding
+}
+
+#[test]
+fn test_sweep_below_threshold_rejected() {
+    let (env, _, owner, pool, client) = setup();
+    let keeper = Address::generate(&env);
+    let plan_id = client.create_plan(
+        &owner,
+        &pool,
+        &ReinvestStrategy::SamePool,
+        &ReinvestSchedule::RealTime,
+        &1_000,
+        &Vec::new(&env),
+    );
+
+    let result = client.try_sweep(&keeper, &plan_id, &pool, &50, &false, &1);
+    assert_eq!(result.unwrap_err().unwrap(), ReinvestError::BelowThreshold);
+}
+
+#[test]
+fn test_sweep_rejected_when_pool_paused() {
+    let (env, _, owner, pool, client) = setup();
+    let keeper = Address::generate(&env);
+    let plan_id = client.create_plan(
+        &owner,
+        &pool,
+        &ReinvestStrategy::SamePool,
+        &ReinvestSchedule::RealTime,
+        &0,
+        &Vec::new(&env),
+    );
+
+    let result = client.try_sweep(&keeper, &plan_id, &pool, &500, &true, &1);
+    assert_eq!(result.unwrap_err().unwrap(), ReinvestError::PoolPaused);
+}
+
+#[test]
+fn test_sweep_rejected_when_gas_exceeds_earnings() {
+    let (env, _, owner, pool, client) = setup();
+    let keeper = Address::generate(&env);
+    let plan_id = client.create_plan(
+        &owner,
+        &pool,
+        &ReinvestStrategy::SamePool,
+        &ReinvestSchedule::RealTime,
+        &0,
+        &Vec::new(&env),
+    );
+
+    let result = client.try_sweep(&keeper, &plan_id, &pool, &100, &false, &100);
+    assert_eq!(result.unwrap_err().unwrap(), ReinvestError::GasExceedsEarnings);
+}
+
+#[test]
+fn test_sweep_respects_daily_schedule_cadence() {
+    let (env, _, owner, pool, client) = setup();
+    let keeper = Address::generate(&env);
+    let plan_id = client.create_plan(
+        &owner,
+        &pool,
+        &ReinvestStrategy::SamePool,
+        &ReinvestSchedule::Daily,
+        &0,
+        &Vec::new(&env),
+    );
+
+    client.sweep(&keeper, &plan_id, &pool, &500, &false, &1);
+    let result = client.try_sweep(&keeper, &plan_id, &pool, &500, &false, &1);
+    assert_eq!(result.unwrap_err().unwrap(), ReinvestError::ScheduleNotDue);
+
+    env.ledger().with_mut(|l| l.sequence_number += 17_280 + 1);
+    let events = client.sweep(&keeper, &plan_id, &pool, &500, &false, &1);
+    assert_eq!(events.len(), 1);
+}
+
+#[test]
+fn test_pause_blocks_sweep_and_resume_restores_it() {
+    let (env, _, owner, pool, client) = setup();
+    let keeper = Address::generate(&env);
+    let plan_id = client.create_plan(
+        &owner,
+        &pool,
+        &ReinvestStrategy::SamePool,
+        &ReinvestSchedule::RealTime,
+        &0,
+        &Vec::new(&env),
+    );
+
+    client.pause(&owner, &plan_id);
+    let result = client.try_sweep(&keeper, &plan_id, &pool, &500, &false, &1);
+    assert_eq!(result.unwrap_err().unwrap(), ReinvestError::PlanPaused);
+
+    // Strategy is untouched by pause/resume.
+    let plan = client.get_plan(&plan_id).unwrap();
+    assert_eq!(plan.strategy, ReinvestStrategy::SamePool);
+
+    client.resume(&owner, &plan_id);
+    let events = client.sweep(&keeper, &plan_id, &pool, &500, &false, &1);
+    assert_eq!(events.len(), 1);
+}
+
+#[test]
+fn test_pause_by_non_owner_rejected() {
+    let (env, _, owner, pool, client) = setup();
+    let intruder = Address::generate(&env);
+    let plan_id = client.create_plan(
+        &owner,
+        &pool,
+        &ReinvestStrategy::SamePool,
+        &ReinvestSchedule::RealTime,
+        &0,
+        &Vec::new(&env),
+    );
+
+    let result = client.try_pause(&intruder, &plan_id);
+    assert_eq!(result.unwrap_err().unwrap(), ReinvestError::Unauthorized);
+}
+
+#[test]
+fn test_get_user_plans_lists_created_plans() {
+    let (env, _, owner, pool, client) = setup();
+    let plan_a = client.create_plan(
+        &owner,
+        &pool,
+        &ReinvestStrategy::SamePool,
+        &ReinvestSchedule::RealTime,
+        &0,
+        &Vec::new(&env),
+    );
+    let plan_b = client.create_plan(
+        &owner,
+        &pool,
+        &ReinvestStrategy::SamePool,
+        &ReinvestSchedule::Weekly,
+        &0,
+        &Vec::new(&env),
+    );
+
+    let plans = client.get_user_plans(&owner);
+    assert_eq!(plans.len(), 2);
+    assert_eq!(plans.get(0).unwrap(), plan_a);
+    assert_eq!(plans.get(1).unwrap(), plan_b);
+}

--- a/stellar-lend/contracts/shared-math/Cargo.toml
+++ b/stellar-lend/contracts/shared-math/Cargo.toml
@@ -4,8 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-soroban-sdk = { version = "21.5", features = ["contracttype", "testutils"] }
-soroban-contract-sdk = "21.5"
+soroban-sdk = { workspace = true, features = ["testutils"] }
 
 [dev-dependencies]
 proptest = "1.4"

--- a/stellar-lend/contracts/shared-storage/Cargo.toml
+++ b/stellar-lend/contracts/shared-storage/Cargo.toml
@@ -4,5 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-soroban-sdk = { version = "21.5", features = ["contracttype"] }
-soroban-contract-sdk = "21.5"
+soroban-sdk = { workspace = true }

--- a/stellar-lend/tests/integration/flash-loan-liquidation/Cargo.toml
+++ b/stellar-lend/tests/integration/flash-loan-liquidation/Cargo.toml
@@ -4,5 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-soroban-sdk = { version = "21.5", features = ["contracttype", "testutils"] }
-soroban-contract-sdk = "21.5"
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/stellar-lend/tests/simulation/multi-user/Cargo.toml
+++ b/stellar-lend/tests/simulation/multi-user/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-soroban-sdk = { version = "21.5", features = ["contracttype", "testutils"] }
+soroban-sdk = { workspace = true, features = ["testutils"] }
 tokio = { version = "1", features = ["full"] }
 rand = "0.8"
 statrs = "0.16"


### PR DESCRIPTION
## What Changed

Adds an automated earnings reinvestment planner, as scoped in #587:

- `contracts/earnings-reinvest`: a new Soroban contract for reinvestment plans. Supports same-pool, best-APY, and weighted-across-pools strategies; real-time/daily/weekly/threshold schedules; pause/resume without losing the configured strategy; and per-event cost-basis recording for tax-lot accounting. `sweep` enforces threshold, plan-paused, pool-paused, gas-vs-earnings viability, and schedule cadence before executing.
- `api/src/services/earnings/reinvestment.service.ts` + matching controller/routes mounted at `/api/reinvestment/*`: tracks plans, records sweeps (applying the same gating rules as the contract), and serves history/analytics (compounded-vs-manual projection, per-pool breakdown). Follows the existing in-memory-Map service convention used elsewhere in this API (there's no ORM/DB wired up yet).

Also includes an unrelated but necessary `fix:` commit — the workspace and the API were both broken before this PR (a stale/invalid `soroban-sdk` pin in 4 crates broke `cargo build` for the whole Rust workspace, and a bad import plus a non-existent `Logger` export crashed `app.ts` on load, taking every route-level API test down with it). Fixing these was required to build and test this feature at all, and it also restored the full API test suite from 0 runnable suites to 471/471 passing.

**Note on #588, #589, #590:** these were already implemented on `main` (`contracts/compliance`, `contracts/token-adapter`, and `contracts/lending/src/{query,mutation}.rs`) by the time this branch was cut, closely matching their acceptance criteria. This PR only addresses #587, which was the one still missing.

## Why

Lenders currently have to manually reinvest earned interest; #587 asks for an automated planner that sweeps earnings back into pools on a configurable schedule/threshold/strategy.

## Testing

- [x] Unit tests updated or added — 13 new Rust contract tests, 22 new API tests (18 service + 4 route)
- [x] Relevant local checks passed — `cargo test`/`cargo clippy -- -D warnings` for the new crate; `npm run lint`, full `npm test` (471/471 passing) for the API
- [ ] Manual verification completed when needed — not run against a live devnet deployment

## Related Issues

Closes #587
Closes #588
Closes #589
Closes #590