### PR TITLE
test: add unit tests for insurance and liquidation monitor services

### DIFF
--- a/api/src/__tests__/insurance.service.test.ts
+++ b/api/src/__tests__/insurance.service.test.ts
@@ -1,0 +1,156 @@
+import { insuranceService } from '../services/insurance/insurance.service';
+
+describe('InsuranceService', () => {
+  let providerId: string;
+  let policyId: string;
+
+  describe('onboardProvider', () => {
+    it('creates a provider with positive collateral', () => {
+      const provider = insuranceService.onboardProvider({
+        address: 'GPROVIDER1',
+        name: 'InsureCo',
+        kycStatus: 'approved',
+        collateral: 100_000,
+      });
+      expect(provider.id).toBeDefined();
+      expect(provider.availableCollateral).toBe(100_000);
+      expect(provider.rating).toBe(0);
+      providerId = provider.id;
+    });
+
+    it('rejects zero or negative collateral', () => {
+      expect(() =>
+        insuranceService.onboardProvider({
+          address: 'GPROVIDER2',
+          name: 'BadCo',
+          kycStatus: 'approved',
+          collateral: 0,
+        })
+      ).toThrow('Provider collateral must be positive');
+    });
+  });
+
+  describe('createPolicy', () => {
+    it('creates a policy for an approved provider', () => {
+      const policy = insuranceService.createPolicy({
+        providerId,
+        coverageAmount: 50_000,
+        premiumBps: 200,
+        durationDays: 30,
+        terms: 'Covers oracle failures',
+        coveredTriggers: ['oracle_failure'],
+        exclusions: ['self-inflicted'],
+      });
+      expect(policy.id).toBeDefined();
+      expect(policy.active).toBe(true);
+      policyId = policy.id;
+    });
+
+    it('rejects policy when coverage exceeds collateral', () => {
+      expect(() =>
+        insuranceService.createPolicy({
+          providerId,
+          coverageAmount: 999_999,
+          premiumBps: 100,
+          durationDays: 30,
+          terms: 'Too much',
+          coveredTriggers: ['oracle_failure'],
+          exclusions: [],
+        })
+      ).toThrow('Coverage exceeds provider collateral');
+    });
+  });
+
+  describe('listPolicies', () => {
+    it('returns only active policies', () => {
+      const policies = insuranceService.listPolicies();
+      expect(policies.length).toBeGreaterThan(0);
+      expect(policies.every((p) => p.active)).toBe(true);
+    });
+  });
+
+  describe('purchase', () => {
+    it('purchases coverage and deducts collateral', () => {
+      const coverage = insuranceService.purchase(policyId, 'GLENDER1', 'POS1', 10_000);
+      expect(coverage.coverageAmount).toBe(10_000);
+      expect(coverage.premiumPaid).toBe((10_000 * 200) / 10_000);
+      expect(coverage.expiresAt).toBeGreaterThan(coverage.startsAt);
+    });
+
+    it('rejects purchase on inactive policy', () => {
+      expect(() => insuranceService.purchase('nonexistent', 'GLENDER2', 'POS2')).toThrow(
+        'Policy is unavailable'
+      );
+    });
+  });
+
+  describe('submitClaim', () => {
+    let coverageId: string;
+
+    beforeAll(() => {
+      const coverage = insuranceService.purchase(policyId, 'GLENDER3', 'POS3', 5_000);
+      coverageId = coverage.id;
+    });
+
+    it('approves a valid claim with covered trigger', () => {
+      const claim = insuranceService.submitClaim(coverageId, 'oracle_failure', 'tx proof', 3_000);
+      expect(claim.status).toBe('approved');
+      expect(claim.amount).toBe(3_000);
+    });
+
+    it('denies claim with uncovered trigger', () => {
+      const claim = insuranceService.submitClaim(
+        coverageId,
+        'contract_compromise',
+        'no evidence',
+        1_000
+      );
+      expect(claim.status).toBe('denied');
+    });
+
+    it('caps claim amount at coverage amount', () => {
+      const claim = insuranceService.submitClaim(coverageId, 'oracle_failure', 'proof', 99_999);
+      expect(claim.amount).toBeLessThanOrEqual(5_000);
+    });
+  });
+
+  describe('disputeClaim', () => {
+    it('disputes a denied claim', () => {
+      const coverage = insuranceService.purchase(policyId, 'GLENDER4', 'POS4', 2_000);
+      const claim = insuranceService.submitClaim(
+        coverage.id,
+        'contract_compromise',
+        'evidence',
+        1_000
+      );
+      expect(claim.status).toBe('denied');
+
+      const disputed = insuranceService.disputeClaim(claim.id);
+      expect(disputed.status).toBe('disputed');
+      expect(disputed.resolvedAt).toBeUndefined();
+    });
+
+    it('rejects dispute on approved claim', () => {
+      const coverage = insuranceService.purchase(policyId, 'GLENDER5', 'POS5', 2_000);
+      const claim = insuranceService.submitClaim(
+        coverage.id,
+        'oracle_failure',
+        'evidence',
+        1_000
+      );
+      expect(claim.status).toBe('approved');
+      expect(() => insuranceService.disputeClaim(claim.id)).toThrow(
+        'Only denied claims can be disputed'
+      );
+    });
+  });
+
+  describe('dashboard', () => {
+    it('returns claims and totals', () => {
+      const dash = insuranceService.dashboard();
+      expect(dash.claims.length).toBeGreaterThan(0);
+      expect(dash.totals).toHaveProperty('approved');
+      expect(dash.totals).toHaveProperty('denied');
+    });
+  });
+});

--- a/api/src/__tests__/liquidationMonitor.service.test.ts
+++ b/api/src/__tests__/liquidationMonitor.service.test.ts
@@ -1,0 +1,105 @@
+import { LiquidationMonitorService } from '../services/liquidation-monitor/liquidationMonitor.service';
+
+describe('LiquidationMonitorService', () => {
+  let service: LiquidationMonitorService;
+
+  beforeEach(() => {
+    service = new LiquidationMonitorService();
+  });
+
+  describe('getAllPositions', () => {
+    it('returns seed positions sorted by health factor ascending', () => {
+      const positions = service.getAllPositions();
+      expect(positions.length).toBeGreaterThan(0);
+      for (let i = 1; i < positions.length; i++) {
+        expect(positions[i].healthFactor).toBeGreaterThanOrEqual(positions[i - 1].healthFactor);
+      }
+    });
+  });
+
+  describe('getPosition', () => {
+    it('returns a known position', () => {
+      const pos = service.getPosition('GABCDE12345');
+      expect(pos).toBeDefined();
+      expect(pos!.collateralAsset).toBe('XLM');
+    });
+
+    it('returns undefined for unknown address', () => {
+      expect(service.getPosition('GUNKNOWN')).toBeUndefined();
+    });
+  });
+
+  describe('getPositionsByRisk', () => {
+    it('filters by risk category', () => {
+      const critical = service.getPositionsByRisk('critical');
+      expect(critical.length).toBeGreaterThan(0);
+      expect(critical.every((p) => p.riskCategory === 'critical')).toBe(true);
+    });
+
+    it('returns empty for non-existent category', () => {
+      const none = service.getPositionsByRisk('safe' as any);
+      // There's at least one safe position in seed data
+      expect(none.every((p) => p.riskCategory === 'safe')).toBe(true);
+    });
+  });
+
+  describe('getLiquidatablePositions', () => {
+    it('returns positions with health factor below 1.2', () => {
+      const liquidatable = service.getLiquidatablePositions();
+      expect(liquidatable.every((p) => p.healthFactor < 1.2)).toBe(true);
+    });
+
+    it('filters by minimum profit', () => {
+      const profitable = service.getLiquidatablePositions(1000);
+      expect(profitable.every((p) => p.netProfit >= 1000)).toBe(true);
+    });
+  });
+
+  describe('updatePosition', () => {
+    it('updates an existing position', () => {
+      service.updatePosition('GABCDE12345', { healthFactor: 0.95, riskCategory: 'critical' });
+      const pos = service.getPosition('GABCDE12345');
+      expect(pos!.healthFactor).toBe(0.95);
+      expect(pos!.riskCategory).toBe('critical');
+    });
+
+    it('ignores updates to unknown positions', () => {
+      service.updatePosition('GUNKNOWN', { healthFactor: 0.5 });
+      expect(service.getPosition('GUNKNOWN')).toBeUndefined();
+    });
+  });
+
+  describe('thresholds and alerts', () => {
+    it('sets and retrieves threshold', () => {
+      service.setThreshold({
+        address: 'GABCDE12345',
+        dangerHf: 1.0,
+        warningHf: 1.2,
+        enabled: true,
+      });
+      const threshold = service.getThreshold('GABCDE12345');
+      expect(threshold).toBeDefined();
+      expect(threshold!.dangerHf).toBe(1.0);
+    });
+
+    it('returns alerts for positions below threshold', () => {
+      service.setThreshold({
+        address: 'GABCDE12345',
+        dangerHf: 1.5,
+        warningHf: 2.0,
+        enabled: true,
+      });
+      const alerts = service.getAlerts();
+      expect(alerts.some((a) => a.address === 'GABCDE12345')).toBe(true);
+    });
+  });
+
+  describe('onUpdate', () => {
+    it('notifies listeners on position update', () => {
+      const listener = jest.fn();
+      service.onUpdate(listener);
+      service.updatePosition('GABCDE12345', { healthFactor: 1.0 });
+      expect(listener).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
Closes #668
Closes #669
Closes #670
Closes #671

## What changed
- Added unit tests for insurance service (#671): provider onboarding, policy creation, coverage purchase, claim submission, disputes, dashboard
- Added unit tests for liquidation monitor service (#670): position listing, risk filtering, liquidatable positions, thresholds, alerts, listener notifications
- #668 (price aggregation) and #669 (MEV protection) already have comprehensive implementations with existing test suites

## Why
- Insurance and liquidation monitor services lacked test coverage
- These are pure in-memory services with clear public APIs — ideal for unit testing

## How to test
- Run `cd api && npx jest insurance.service.test.ts liquidationMonitor.service.test.ts`