### PR TITLE
feat: oracle health monitoring, rate history, pool optimizer, priority liquidation

### DIFF
--- a/stellar-lend/contracts/hello-world/src/amm.rs
+++ b/stellar-lend/contracts/hello-world/src/amm.rs
@@ -386,3 +386,156 @@ pub fn get_il_snapshot(env: &Env, asset: &Address) -> Option<IlSnapshot> {
         .persistent()
         .get(&AmmLendingKey::IlTracking(asset.clone()))
 }
+
+// ─── Pool Allocation Optimizer (#682) ─────────────────────────────────────────
+
+/// Target utilization for optimal capital efficiency (80%)
+const OPTIMAL_UTILIZATION_BPS: i128 = 8000;
+
+/// Minimum rebalance threshold (5% difference to trigger rebalance)
+const REBALANCE_THRESHOLD_BPS: i128 = 500;
+
+/// Pool allocation recommendation
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct AllocationRecommendation {
+    pub asset: Address,
+    pub current_utilization_bps: i128,
+    pub recommended_allocation_bps: i128,
+    pub action: AllocationAction,
+    pub amount: i128,
+}
+
+/// Action to take for allocation optimization
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum AllocationAction {
+    /// Move funds into this pool (under-utilized)
+    Increase,
+    /// Move funds out of this pool (over-utilized)
+    Decrease,
+    /// No change needed
+    NoChange,
+}
+
+/// Result of an optimization pass
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct OptimizationResult {
+    pub recommendations: Vec<AllocationRecommendation>,
+    pub total_capital_efficiency_bps: i128,
+    pub estimated_yield_improvement_bps: i128,
+}
+
+/// Analyze pool utilization and recommend allocation changes.
+///
+/// Examines all tracked pools and recommends rebalancing actions to
+/// maximize capital efficiency while maintaining safety buffers.
+pub fn optimize_allocation(
+    env: &Env,
+    pools: &Vec<Address>,
+) -> Result<OptimizationResult, AmmError> {
+    let mut recommendations: Vec<AllocationRecommendation> = Vec::new(env);
+    let mut total_utilization: i128 = 0;
+    let mut pool_count: i128 = 0;
+
+    for pool in pools.iter() {
+        let utilization_key = AmmLendingKey::PoolUtilization(pool.clone());
+        let current_utilization: i128 = env
+            .storage()
+            .persistent()
+            .get::<AmmLendingKey, i128>(&utilization_key)
+            .unwrap_or(0);
+
+        total_utilization = total_utilization.saturating_add(current_utilization);
+        pool_count = pool_count.saturating_add(1);
+
+        let deviation = if current_utilization > OPTIMAL_UTILIZATION_BPS {
+            current_utilization - OPTIMAL_UTILIZATION_BPS
+        } else {
+            OPTIMAL_UTILIZATION_BPS - current_utilization
+        };
+
+        let (action, amount) = if deviation < REBALANCE_THRESHOLD_BPS {
+            (AllocationAction::NoChange, 0)
+        } else if current_utilization < OPTIMAL_UTILIZATION_BPS {
+            // Under-utilized — increase allocation
+            let buffer_key = AmmLendingKey::WithdrawalBufferBps(pool.clone());
+            let buffer_bps: i128 = env
+                .storage()
+                .persistent()
+                .get::<AmmLendingKey, i128>(&buffer_key)
+                .unwrap_or(DEFAULT_WITHDRAWAL_BUFFER_BPS);
+            let available = BPS_SCALE.saturating_sub(buffer_bps);
+            let increase_amount = available
+                .saturating_mul(OPTIMAL_UTILIZATION_BPS - current_utilization)
+                .checked_div(BPS_SCALE)
+                .unwrap_or(0);
+            (AllocationAction::Increase, increase_amount)
+        } else {
+            // Over-utilized — decrease allocation
+            let excess = current_utilization - OPTIMAL_UTILIZATION_BPS;
+            let decrease_amount = excess
+                .saturating_mul(current_utilization)
+                .checked_div(BPS_SCALE)
+                .unwrap_or(0);
+            (AllocationAction::Decrease, decrease_amount)
+        };
+
+        recommendations.push_back(AllocationRecommendation {
+            asset: pool.clone(),
+            current_utilization_bps: current_utilization,
+            recommended_allocation_bps: OPTIMAL_UTILIZATION_BPS,
+            action,
+            amount,
+        });
+    }
+
+    let avg_utilization = if pool_count > 0 {
+        total_utilization.checked_div(pool_count).unwrap_or(0)
+    } else {
+        0
+    };
+
+    // Estimate yield improvement: closer to optimal = better yield
+    let efficiency = if avg_utilization <= OPTIMAL_UTILIZATION_BPS {
+        avg_utilization
+    } else {
+        // Over-utilization means higher rates but more risk
+        OPTIMAL_UTILIZATION_BPS
+    };
+
+    // Yield improvement estimate: moving from current to optimal
+    let yield_improvement = if avg_utilization < OPTIMAL_UTILIZATION_BPS {
+        (OPTIMAL_UTILIZATION_BPS - avg_utilization).checked_div(100).unwrap_or(0)
+    } else {
+        0
+    };
+
+    Ok(OptimizationResult {
+        recommendations,
+        total_capital_efficiency_bps: efficiency,
+        estimated_yield_improvement_bps: yield_improvement,
+    })
+}
+
+/// Update the utilization snapshot for a pool.
+///
+/// Should be called whenever deposits/withdrawals/borrows change pool state.
+pub fn update_pool_utilization(
+    env: &Env,
+    asset: &Address,
+    utilization_bps: i128,
+) {
+    let key = AmmLendingKey::PoolUtilization(asset.clone());
+    env.storage().persistent().set(&key, &utilization_bps);
+}
+
+/// Get the current utilization snapshot for a pool.
+pub fn get_pool_utilization(env: &Env, asset: &Address) -> i128 {
+    let key = AmmLendingKey::PoolUtilization(asset.clone());
+    env.storage()
+        .persistent()
+        .get::<AmmLendingKey, i128>(&key)
+        .unwrap_or(0)
+}

--- a/stellar-lend/contracts/hello-world/src/interest_rate.rs
+++ b/stellar-lend/contracts/hello-world/src/interest_rate.rs
@@ -568,3 +568,182 @@ pub fn compute_index_interest(
         .ok_or(InterestRateError::DivisionByZero)?;
     Ok(interest)
 }
+
+// ── Rate History & Dynamic Adjustment (#681) ───────────────────────────────
+
+/// Maximum number of rate history entries to keep per asset
+const MAX_RATE_HISTORY: u32 = 100;
+
+/// A snapshot of the interest rate at a point in time
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct RateHistoryEntry {
+    /// Borrow rate at this point (bps)
+    pub borrow_rate_bps: i128,
+    /// Supply rate at this point (bps)
+    pub supply_rate_bps: i128,
+    /// Utilization at this point (bps)
+    pub utilization_bps: i128,
+    /// Timestamp of the snapshot
+    pub timestamp: u64,
+}
+
+/// Storage keys for rate history
+#[contracttype]
+#[derive(Clone)]
+pub enum RateHistoryKey {
+    /// Vec<RateHistoryEntry> — rolling window of rate snapshots
+    RateHistory,
+    /// RateHistoryEntry — the last recorded snapshot
+    LastSnapshot,
+}
+
+/// Record a rate snapshot in the history.
+///
+/// Should be called whenever interest is accrued or rates are updated.
+pub fn record_rate_snapshot(env: &Env) -> Result<(), InterestRateError> {
+    let borrow_rate = calculate_borrow_rate(env)?;
+    let supply_rate = calculate_supply_rate(env)?;
+    let utilization = calculate_utilization(env)?;
+    let now = env.ledger().timestamp();
+
+    let entry = RateHistoryEntry {
+        borrow_rate_bps: borrow_rate,
+        supply_rate_bps: supply_rate,
+        utilization_bps: utilization,
+        timestamp: now,
+    };
+
+    // Store as last snapshot
+    env.storage()
+        .persistent()
+        .set(&RateHistoryKey::LastSnapshot, &entry);
+
+    // Append to rolling history
+    let history_key = RateHistoryKey::RateHistory;
+    let mut history: Vec<RateHistoryEntry> = env
+        .storage()
+        .persistent()
+        .get::<RateHistoryKey, Vec<RateHistoryEntry>>(&history_key)
+        .unwrap_or_else(|| Vec::new(env));
+
+    history.push_back(entry);
+
+    // Trim to max size
+    let mut trimmed: Vec<RateHistoryEntry> = Vec::new(env);
+    let start = if history.len() as u32 > MAX_RATE_HISTORY {
+        history.len() - MAX_RATE_HISTORY
+    } else {
+        0
+    };
+    for i in start..history.len() {
+        trimmed.push_back(history.get(i).unwrap());
+    }
+
+    env.storage().persistent().set(&history_key, &trimmed);
+
+    Ok(())
+}
+
+/// Get the rate history.
+pub fn get_rate_history(env: &Env) -> Vec<RateHistoryEntry> {
+    let key = RateHistoryKey::RateHistory;
+    env.storage()
+        .persistent()
+        .get::<RateHistoryKey, Vec<RateHistoryEntry>>(&key)
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+/// Get the last recorded rate snapshot.
+pub fn get_last_rate_snapshot(env: &Env) -> Option<RateHistoryEntry> {
+    env.storage()
+        .persistent()
+        .get::<RateHistoryKey, RateHistoryEntry>(&RateHistoryKey::LastSnapshot)
+}
+
+/// Simulate what the borrow rate would be at a given utilization level.
+///
+/// Does not modify state — purely a read-only calculation.
+///
+/// # Arguments
+/// * `env` - The Soroban environment
+/// * `target_utilization_bps` - The utilization to simulate (0-10000)
+///
+/// # Returns
+/// The simulated borrow rate in basis points
+pub fn simulate_rate_at_utilization(
+    env: &Env,
+    target_utilization_bps: i128,
+) -> Result<i128, InterestRateError> {
+    let config = get_interest_rate_config(env).ok_or(InterestRateError::InvalidParameter)?;
+
+    if target_utilization_bps < 0 || target_utilization_bps > BASIS_POINTS_SCALE {
+        return Err(InterestRateError::InvalidParameter);
+    }
+
+    let mut rate = config.base_rate_bps;
+
+    if target_utilization_bps <= config.kink_utilization_bps {
+        if config.kink_utilization_bps > 0 {
+            let rate_increase = target_utilization_bps
+                .checked_mul(config.multiplier_bps)
+                .ok_or(InterestRateError::Overflow)?
+                .checked_div(config.kink_utilization_bps)
+                .ok_or(InterestRateError::DivisionByZero)?;
+            rate = rate
+                .checked_add(rate_increase)
+                .ok_or(InterestRateError::Overflow)?;
+        }
+    } else {
+        let rate_at_kink = config
+            .base_rate_bps
+            .checked_add(config.multiplier_bps)
+            .ok_or(InterestRateError::Overflow)?;
+
+        let above_kink = target_utilization_bps
+            .checked_sub(config.kink_utilization_bps)
+            .ok_or(InterestRateError::Overflow)?;
+
+        let max_above = BASIS_POINTS_SCALE
+            .checked_sub(config.kink_utilization_bps)
+            .ok_or(InterestRateError::Overflow)?;
+
+        if max_above > 0 {
+            let additional = above_kink
+                .checked_mul(config.jump_multiplier_bps)
+                .ok_or(InterestRateError::Overflow)?
+                .checked_div(max_above)
+                .ok_or(InterestRateError::DivisionByZero)?;
+            rate = rate_at_kink
+                .checked_add(additional)
+                .ok_or(InterestRateError::Overflow)?;
+        } else {
+            rate = rate_at_kink;
+        }
+    }
+
+    rate = rate
+        .checked_add(config.emergency_adjustment_bps)
+        .ok_or(InterestRateError::Overflow)?;
+
+    Ok(rate.max(config.rate_floor_bps).min(config.rate_ceiling_bps))
+}
+
+/// Get the average borrow rate over the recorded history.
+pub fn get_average_borrow_rate(env: &Env) -> Result<i128, InterestRateError> {
+    let history = get_rate_history(env);
+    if history.is_empty() {
+        return Ok(0);
+    }
+
+    let mut total: i128 = 0;
+    for entry in history.iter() {
+        total = total
+            .checked_add(entry.borrow_rate_bps)
+            .ok_or(InterestRateError::Overflow)?;
+    }
+
+    total
+        .checked_div(history.len() as i128)
+        .ok_or(InterestRateError::DivisionByZero)
+}

--- a/stellar-lend/contracts/hello-world/src/liquidate.rs
+++ b/stellar-lend/contracts/hello-world/src/liquidate.rs
@@ -55,6 +55,9 @@ pub struct BatchLiquidationRequest {
     pub debt_asset: Option<Address>,
     pub collateral_asset: Option<Address>,
     pub debt_amount: i128,
+    /// Priority score for ordering (higher = process first).
+    /// Typically based on profit potential. 0 = use default ordering.
+    pub priority_score: u64,
 }
 
 /// Per-position result within a batch liquidation
@@ -791,11 +794,94 @@ fn update_liquidation_analytics(
     Ok(())
 }
 
+/// Sort batch liquidation requests by priority score (descending).
+///
+/// Uses insertion sort — efficient for small batches (MAX_BATCH_SIZE = 10).
+/// Requests with higher priority_score are processed first, maximizing
+/// profit potential per gas unit spent.
+fn sort_by_priority(
+    env: &Env,
+    requests: &Vec<BatchLiquidationRequest>,
+) -> Vec<BatchLiquidationRequest> {
+    let n = requests.len();
+    let mut sorted: Vec<BatchLiquidationRequest> = Vec::new(env);
+
+    for i in 0..n {
+        let item = requests.get(i).unwrap();
+        let mut insert_pos = sorted.len();
+
+        // Find insertion point (descending order by priority_score)
+        for j in 0..sorted.len() {
+            let existing = sorted.get(j).unwrap();
+            if item.priority_score > existing.priority_score {
+                insert_pos = j;
+                break;
+            }
+        }
+
+        // Insert at the correct position
+        sorted.insert(insert_pos, item);
+    }
+
+    sorted
+}
+
+/// Calculate the profit potential score for a liquidation request.
+///
+/// Higher scores indicate more profitable liquidations. The score is based on
+/// the ratio of debt to collateral and the incentive available.
+pub fn calculate_priority_score(
+    env: &Env,
+    request: &BatchLiquidationRequest,
+) -> Result<u64, LiquidationError> {
+    let position_key = DepositDataKey::Position(request.borrower.clone());
+    let position = env
+        .storage()
+        .persistent()
+        .get::<DepositDataKey, Position>(&position_key);
+
+    let Some(pos) = position else {
+        return Ok(0);
+    };
+
+    let total_debt = pos.debt.saturating_add(pos.borrow_interest);
+    if total_debt == 0 {
+        return Ok(0);
+    }
+
+    // Get collateral value
+    let collateral_key = DepositDataKey::CollateralBalance(request.borrower.clone());
+    let collateral: i128 = env
+        .storage()
+        .persistent()
+        .get::<DepositDataKey, i128>(&collateral_key)
+        .unwrap_or(0);
+
+    // Score = (collateral / debt) * 10000 — higher means more collateral to seize
+    // Also factor in the debt amount (larger liquidations are more profitable)
+    let collateral_ratio = collateral
+        .saturating_mul(10_000)
+        .checked_div(total_debt)
+        .unwrap_or(0);
+
+    // Combine ratio and absolute amount for priority
+    // Normalize debt amount to a reasonable scale (divide by 1e6)
+    let debt_scale = request.debt_amount.checked_div(1_000_000).unwrap_or(0) as u64;
+
+    let score = (collateral_ratio as u64)
+        .saturating_add(debt_scale);
+
+    Ok(score)
+}
+
 /// Liquidate multiple undercollateralized positions in a single atomic transaction.
 ///
 /// Processes up to `MAX_BATCH_SIZE` positions in one call, reducing the per-position
 /// overhead of separate transaction submissions. Per-position failures are captured in
 /// the result and do not abort the entire batch.
+///
+/// Requests are sorted by priority_score (descending) before processing,
+/// ensuring the most profitable liquidations are executed first.
 ///
 /// Authorization and rate-limiting are applied once in the contract entry point
 /// (`lib.rs`), not here.
@@ -811,6 +897,9 @@ pub fn batch_liquidate(
         return Err(LiquidationError::InvalidAmount);
     }
 
+    // Sort by priority (most profitable first)
+    let sorted_requests = sort_by_priority(env, &requests);
+
     let timestamp = env.ledger().timestamp();
     let mut results: Vec<BatchLiquidationResult> = Vec::new(env);
     let mut total_debt_liquidated: i128 = 0;
@@ -818,9 +907,9 @@ pub fn batch_liquidate(
     let mut successful: u32 = 0;
     let mut failed: u32 = 0;
 
-    let n = requests.len();
+    let n = sorted_requests.len();
     for i in 0..n {
-        let req = requests.get(i).unwrap();
+        let req = sorted_requests.get(i).unwrap();
         let outcome = liquidate(
             env,
             liquidator.clone(),

--- a/stellar-lend/contracts/hello-world/src/oracle.rs
+++ b/stellar-lend/contracts/hello-world/src/oracle.rs
@@ -1480,3 +1480,201 @@ pub fn get_oracle_incident_report(env: &Env, asset: &Address) -> Option<OracleIn
         .persistent()
         .get::<OracleDataKey, OracleIncidentReport>(&key)
 }
+
+// ── Automatic Oracle Health Monitoring (#680) ──────────────────────────────
+
+/// Consecutive failure threshold before auto-triggering circuit breaker
+const AUTO_BREAKER_FAILURE_THRESHOLD: u32 = 3;
+
+/// Storage key extension for tracking consecutive oracle failures per asset
+#[contracttype]
+#[derive(Clone)]
+pub enum OracleHealthKey {
+    /// Number of consecutive price fetch failures for an asset
+    ConsecutiveFailures(Address),
+    /// Timestamp of the last successful price fetch
+    LastSuccess(Address),
+    /// Incident timeline: recent incidents for an asset
+    IncidentTimeline(Address),
+}
+
+/// An entry in the oracle incident timeline
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct IncidentTimelineEntry {
+    pub kind: OracleIncidentKind,
+    pub timestamp: u64,
+    pub resolved: bool,
+    pub resolved_at: u64,
+}
+
+/// Result of an oracle health check
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct OracleHealthStatus {
+    pub asset: Address,
+    pub consecutive_failures: u32,
+    pub last_success_timestamp: u64,
+    pub circuit_breaker_open: bool,
+    pub auto_triggered: bool,
+}
+
+/// Monitor oracle health for an asset and auto-trigger circuit breaker if needed.
+///
+/// This function should be called after each failed price fetch. It tracks
+/// consecutive failures and automatically activates the circuit breaker when
+/// the failure threshold is reached.
+///
+/// # Arguments
+/// * `env` - The Soroban environment
+/// * `asset` - The asset address to monitor
+///
+/// # Returns
+/// `OracleHealthStatus` with the current health state
+pub fn monitor_oracle_health(
+    env: &Env,
+    asset: &Address,
+) -> Result<OracleHealthStatus, OracleError> {
+    let failures_key = OracleHealthKey::ConsecutiveFailures(asset.clone());
+    let mut failures: u32 = env
+        .storage()
+        .persistent()
+        .get::<OracleHealthKey, u32>(&failures_key)
+        .unwrap_or(0);
+
+    failures = failures.saturating_add(1);
+    env.storage().persistent().set(&failures_key, &failures);
+
+    let last_success_key = OracleHealthKey::LastSuccess(asset.clone());
+    let last_success: u64 = env
+        .storage()
+        .persistent()
+        .get::<OracleHealthKey, u64>(&last_success_key)
+        .unwrap_or(0);
+
+    let breaker_open = is_breaker_open(env, asset);
+    let mut auto_triggered = false;
+
+    // Auto-trigger circuit breaker if consecutive failures exceed threshold
+    if failures >= AUTO_BREAKER_FAILURE_THRESHOLD && !breaker_open {
+        let config = get_oracle_config(env);
+        let now = env.ledger().timestamp();
+        let open_until = now.saturating_add(config.breaker_cooldown_seconds);
+
+        let state = CircuitBreakerState {
+            open_until,
+            last_safe_price: 0,
+            last_trip_timestamp: now,
+        };
+        set_breaker_state(env, asset, &state);
+
+        write_incident_report(
+            env,
+            asset,
+            OracleIncidentKind::StalePrice,
+            failures as i128,
+            AUTO_BREAKER_FAILURE_THRESHOLD as i128,
+            0,
+            0,
+            open_until,
+        );
+
+        // Append to incident timeline
+        append_incident_timeline(env, asset, OracleIncidentKind::StalePrice);
+
+        auto_triggered = true;
+    }
+
+    Ok(OracleHealthStatus {
+        asset: asset.clone(),
+        consecutive_failures: failures,
+        last_success_timestamp: last_success,
+        circuit_breaker_open: is_breaker_open(env, asset),
+        auto_triggered,
+    })
+}
+
+/// Record a successful oracle fetch, resetting the consecutive failure counter.
+///
+/// Call this after a successful price update to indicate the oracle is healthy.
+pub fn record_oracle_success(env: &Env, asset: &Address) {
+    let failures_key = OracleHealthKey::ConsecutiveFailures(asset.clone());
+    env.storage().persistent().set(&failures_key, &0u32);
+
+    let last_success_key = OracleHealthKey::LastSuccess(asset.clone());
+    env.storage()
+        .persistent()
+        .set(&last_success_key, &env.ledger().timestamp());
+}
+
+/// Append an incident to the asset's incident timeline.
+fn append_incident_timeline(env: &Env, asset: &Address, kind: OracleIncidentKind) {
+    let key = OracleHealthKey::IncidentTimeline(asset.clone());
+    let mut timeline: Vec<IncidentTimelineEntry> = env
+        .storage()
+        .persistent()
+        .get::<OracleHealthKey, Vec<IncidentTimelineEntry>>(&key)
+        .unwrap_or_else(|| Vec::new(env));
+
+    timeline.push_back(IncidentTimelineEntry {
+        kind,
+        timestamp: env.ledger().timestamp(),
+        resolved: false,
+        resolved_at: 0,
+    });
+
+    // Keep only the last 50 entries to bound storage
+    let max_entries: u32 = 50;
+    let mut trimmed: Vec<IncidentTimelineEntry> = Vec::new(env);
+    let start = if timeline.len() as u32 > max_entries {
+        timeline.len() - max_entries as u32
+    } else {
+        0
+    };
+    for i in start..timeline.len() {
+        trimmed.push_back(timeline.get(i).unwrap());
+    }
+
+    env.storage().persistent().set(&key, &trimmed);
+}
+
+/// Mark the latest incident for an asset as resolved.
+pub fn resolve_oracle_incident(env: &Env, asset: &Address) {
+    let key = OracleHealthKey::IncidentTimeline(asset.clone());
+    let mut timeline: Vec<IncidentTimelineEntry> = env
+        .storage()
+        .persistent()
+        .get::<OracleHealthKey, Vec<IncidentTimelineEntry>>(&key)
+        .unwrap_or_else(|| Vec::new(env));
+
+    if timeline.is_empty() {
+        return;
+    }
+
+    let last_idx = timeline.len() - 1;
+    let mut last = timeline.get(last_idx).unwrap();
+    if !last.resolved {
+        last.resolved = true;
+        last.resolved_at = env.ledger().timestamp();
+        timeline.set(last_idx, last);
+        env.storage().persistent().set(&key, &timeline);
+    }
+}
+
+/// Get the incident timeline for an asset.
+pub fn get_incident_timeline(env: &Env, asset: &Address) -> Vec<IncidentTimelineEntry> {
+    let key = OracleHealthKey::IncidentTimeline(asset.clone());
+    env.storage()
+        .persistent()
+        .get::<OracleHealthKey, Vec<IncidentTimelineEntry>>(&key)
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+/// Get the number of consecutive failures for an asset.
+pub fn get_consecutive_failures(env: &Env, asset: &Address) -> u32 {
+    let key = OracleHealthKey::ConsecutiveFailures(asset.clone());
+    env.storage()
+        .persistent()
+        .get::<OracleHealthKey, u32>(&key)
+        .unwrap_or(0)
+}


### PR DESCRIPTION
Fixes #680, Fixes #681, Fixes #682, Fixes #683

## What changed

**#680 — Oracle incident monitoring with automatic circuit breaking**
- Added `monitor_oracle_health()` — tracks consecutive failures per asset and auto-triggers circuit breaker after 3 failures
- Added `record_oracle_success()` — resets failure counter on successful price fetch
- Added incident timeline tracking with `append_incident_timeline()` and `resolve_oracle_incident()`
- Added `get_consecutive_failures()` and `get_incident_timeline()` for monitoring infrastructure

**#681 — Interest rate model with dynamic parameter adjustment**
- Added `record_rate_snapshot()` — captures borrow/supply rates and utilization at each accrual
- Added `simulate_rate_at_utilization()` — read-only simulation of rates at any utilization level
- Added `get_rate_history()` and `get_average_borrow_rate()` for rate analytics
- Rolling window of 100 snapshots bounded in storage

**#682 — Lending pool optimizer with automated allocation**
- Added `optimize_allocation()` — analyzes all pools and recommends Increase/Decrease/NoChange actions
- Uses optimal utilization target (80%) with 5% rebalance threshold
- Added `update_pool_utilization()` and `get_pool_utilization()` for tracking
- Returns `OptimizationResult` with efficiency metrics and yield improvement estimates

**#683 — Batch liquidation with priority ordering**
- Added `priority_score` field to `BatchLiquidationRequest`
- Added `sort_by_priority()` — insertion sort by profit potential (descending)
- Added `calculate_priority_score()` — scores based on collateral ratio and debt size
- `batch_liquidate()` now sorts requests before processing

## Why
- Oracle failures need automatic detection, not manual monitoring
- Rate history enables governance decisions and analytics
- Pool optimization maximizes capital efficiency
- Priority ordering ensures most profitable liquidations execute first

## How to test
`cargo test` in `stellar-lend/contracts/hello-world/`