### PR TITLE
feat: yield farming strategy optimizer with auto-compounding

### DIFF
--- a/api/src/controllers/staking.controller.ts
+++ b/api/src/controllers/staking.controller.ts
@@ -5,6 +5,9 @@ import type {
   UnstakeRequest,
   DelegateRequest,
   RevokeDelegationRequest,
+  CreateYieldStrategyRequest,
+  ActivateYieldStrategyRequest,
+  CompoundStrategyRequest,
 } from '../types/staking';
 
 export const stake = async (req: Request, res: Response, next: NextFunction) => {
@@ -77,6 +80,158 @@ export const getAllPositions = async (_req: Request, res: Response, next: NextFu
   try {
     const positions = stakingService.getAllPositions();
     return res.status(200).json({ success: true, positions, total: positions.length });
+  } catch (err) {
+    next(err);
+    return;
+  }
+};
+
+// ─── Yield Farming Strategy Optimizer Controllers ─────────────────────────────
+
+/**
+ * POST /api/staking/yield-strategies
+ * Create a new yield farming strategy for the authenticated user.
+ */
+export const createYieldStrategy = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const body = req.body as CreateYieldStrategyRequest;
+    const strategy = stakingService.createYieldStrategy(body);
+    return res.status(201).json({ success: true, strategy });
+  } catch (err) {
+    next(err);
+    return;
+  }
+};
+
+/**
+ * GET /api/staking/yield-strategies
+ * List all available strategies (admin / discovery view).
+ */
+export const getAllYieldStrategies = async (_req: Request, res: Response, next: NextFunction) => {
+  try {
+    const strategies = stakingService.getAllYieldStrategies();
+    return res.status(200).json({ success: true, strategies, total: strategies.length });
+  } catch (err) {
+    next(err);
+    return;
+  }
+};
+
+/**
+ * GET /api/staking/yield-strategies/:userAddress
+ * List all strategies belonging to a specific user.
+ */
+export const getUserYieldStrategies = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { userAddress } = req.params;
+    const strategies = stakingService.getUserYieldStrategies(userAddress!);
+    return res.status(200).json({ success: true, strategies, total: strategies.length });
+  } catch (err) {
+    next(err);
+    return;
+  }
+};
+
+/**
+ * POST /api/staking/yield-strategies/:userAddress/activate
+ * Activate a strategy for the given user.
+ * Body: { strategyId }
+ */
+export const activateYieldStrategy = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { userAddress } = req.params;
+    const body = req.body as Omit<ActivateYieldStrategyRequest, 'userAddress'>;
+    const strategy = stakingService.activateYieldStrategy({
+      userAddress: userAddress!,
+      strategyId: body.strategyId,
+    });
+    return res.status(200).json({ success: true, strategy });
+  } catch (err) {
+    next(err);
+    return;
+  }
+};
+
+/**
+ * POST /api/staking/yield-strategies/:userAddress/compound
+ * Manually trigger auto-compounding for the user's active strategy.
+ * Body: { strategyId }
+ */
+export const compoundStrategy = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { userAddress } = req.params;
+    const body = req.body as Omit<CompoundStrategyRequest, 'userAddress'>;
+    const result = stakingService.compoundStrategy({
+      userAddress: userAddress!,
+      strategyId: body.strategyId,
+    });
+    return res.status(200).json({ success: true, ...result });
+  } catch (err) {
+    next(err);
+    return;
+  }
+};
+
+/**
+ * GET /api/staking/yield-strategies/:userAddress/performance/:strategyId
+ * Fetch aggregated performance history for a specific strategy.
+ */
+export const getStrategyPerformance = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { userAddress, strategyId } = req.params;
+    const performance = stakingService.getStrategyPerformance(strategyId!, userAddress!);
+    return res.status(200).json({ success: true, performance });
+  } catch (err) {
+    next(err);
+    return;
+  }
+};
+
+/**
+ * GET /api/staking/yield-optimization
+ * Run the pool allocation optimizer and return rebalancing recommendations.
+ * Query params:
+ *   pools  – comma-separated list of pool addresses (required)
+ *   util   – optional JSON object of { poolAddress: utilizationBps } overrides
+ */
+export const getYieldOptimization = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const poolsParam = req.query['pools'] as string | undefined;
+    if (!poolsParam) {
+      return res
+        .status(400)
+        .json({ success: false, error: 'Query param "pools" is required (comma-separated addresses)' });
+    }
+
+    const poolAddresses = poolsParam
+      .split(',')
+      .map((p) => p.trim())
+      .filter(Boolean);
+
+    if (poolAddresses.length === 0) {
+      return res
+        .status(400)
+        .json({ success: false, error: 'At least one pool address is required' });
+    }
+
+    // Optional utilization overrides passed as a JSON string in the `util` query param
+    let utilizationMap: Record<string, number> = {};
+    const utilParam = req.query['util'] as string | undefined;
+    if (utilParam) {
+      try {
+        utilizationMap = JSON.parse(utilParam) as Record<string, number>;
+      } catch {
+        return res
+          .status(400)
+          .json({ success: false, error: 'Query param "util" must be valid JSON' });
+      }
+    }
+
+    const recommendation = stakingService.getYieldOptimizationRecommendation(
+      poolAddresses,
+      utilizationMap
+    );
+    return res.status(200).json({ success: true, recommendation });
   } catch (err) {
     next(err);
     return;

--- a/api/src/routes/staking.routes.ts
+++ b/api/src/routes/staking.routes.ts
@@ -1,8 +1,11 @@
 import { Router } from 'express';
+import { body, param, query } from 'express-validator';
 import * as stakingController from '../controllers/staking.controller';
+import { validateRequest } from '../middleware/validation';
 
 const router: Router = Router();
 
+// ─── Existing staking / governance routes ────────────────────────────────────
 router.post('/stake', stakingController.stake);
 router.post('/unstake', stakingController.unstake);
 router.post('/delegate', stakingController.delegate);
@@ -10,5 +13,138 @@ router.post('/revoke-delegation', stakingController.revokeDelegation);
 router.post('/claim-rewards/:userAddress', stakingController.claimRewards);
 router.get('/positions', stakingController.getAllPositions);
 router.get('/positions/:userAddress', stakingController.getPosition);
+
+// ─── Yield Farming Strategy Optimizer routes (#789) ──────────────────────────
+
+/**
+ * POST /api/staking/yield-strategies
+ * Create a new yield farming strategy.
+ *
+ * Body:
+ *   userAddress         string   – Stellar address of the strategy owner
+ *   name                string   – Human-readable strategy name
+ *   objective           string   – 'maximize_apy' | 'minimize_il' | 'balanced'
+ *   riskTier            string   – 'conservative' | 'balanced' | 'aggressive'
+ *   compoundingInterval string   – 'hourly' | 'daily' | 'weekly' | 'manual'
+ *   pools               array    – [{ poolAddress, allocationBps, estimatedApy }]
+ *   autoCompoundEnabled boolean  – (optional, default true)
+ */
+router.post(
+  '/yield-strategies',
+  [
+    body('userAddress').isString().notEmpty().withMessage('userAddress is required'),
+    body('name').isString().notEmpty().withMessage('name is required'),
+    body('objective')
+      .isIn(['maximize_apy', 'minimize_il', 'balanced'])
+      .withMessage('objective must be maximize_apy | minimize_il | balanced'),
+    body('riskTier')
+      .isIn(['conservative', 'balanced', 'aggressive'])
+      .withMessage('riskTier must be conservative | balanced | aggressive'),
+    body('compoundingInterval')
+      .isIn(['hourly', 'daily', 'weekly', 'manual'])
+      .withMessage('compoundingInterval must be hourly | daily | weekly | manual'),
+    body('pools').isArray({ min: 1 }).withMessage('pools must be a non-empty array'),
+    body('pools.*.poolAddress')
+      .isString()
+      .notEmpty()
+      .withMessage('Each pool must have a poolAddress'),
+    body('pools.*.allocationBps')
+      .isInt({ min: 1 })
+      .withMessage('Each pool allocationBps must be a positive integer'),
+    body('pools.*.estimatedApy')
+      .isFloat({ min: 0 })
+      .withMessage('Each pool estimatedApy must be a non-negative number'),
+    body('autoCompoundEnabled').optional().isBoolean(),
+  ],
+  validateRequest,
+  stakingController.createYieldStrategy
+);
+
+/**
+ * GET /api/staking/yield-strategies
+ * List all yield farming strategies (discovery / admin view).
+ */
+router.get('/yield-strategies', stakingController.getAllYieldStrategies);
+
+/**
+ * GET /api/staking/yield-strategies/:userAddress
+ * List all strategies owned by a specific user.
+ */
+router.get(
+  '/yield-strategies/:userAddress',
+  [
+    param('userAddress').isString().notEmpty().withMessage('userAddress param is required'),
+  ],
+  validateRequest,
+  stakingController.getUserYieldStrategies
+);
+
+/**
+ * POST /api/staking/yield-strategies/:userAddress/activate
+ * Activate a strategy for the given user.
+ *
+ * Body:
+ *   strategyId  string  – UUID of the strategy to activate
+ */
+router.post(
+  '/yield-strategies/:userAddress/activate',
+  [
+    param('userAddress').isString().notEmpty().withMessage('userAddress param is required'),
+    body('strategyId').isString().notEmpty().withMessage('strategyId is required'),
+  ],
+  validateRequest,
+  stakingController.activateYieldStrategy
+);
+
+/**
+ * POST /api/staking/yield-strategies/:userAddress/compound
+ * Manually trigger auto-compounding for a strategy.
+ *
+ * Body:
+ *   strategyId  string  – UUID of the strategy to compound
+ */
+router.post(
+  '/yield-strategies/:userAddress/compound',
+  [
+    param('userAddress').isString().notEmpty().withMessage('userAddress param is required'),
+    body('strategyId').isString().notEmpty().withMessage('strategyId is required'),
+  ],
+  validateRequest,
+  stakingController.compoundStrategy
+);
+
+/**
+ * GET /api/staking/yield-strategies/:userAddress/performance/:strategyId
+ * Fetch aggregated performance history for a strategy.
+ */
+router.get(
+  '/yield-strategies/:userAddress/performance/:strategyId',
+  [
+    param('userAddress').isString().notEmpty().withMessage('userAddress param is required'),
+    param('strategyId').isString().notEmpty().withMessage('strategyId param is required'),
+  ],
+  validateRequest,
+  stakingController.getStrategyPerformance
+);
+
+/**
+ * GET /api/staking/yield-optimization
+ * Run the pool allocation optimizer and return rebalancing recommendations.
+ *
+ * Query params:
+ *   pools  – comma-separated pool addresses (required)
+ *   util   – optional JSON string { poolAddress: utilizationBps } overrides
+ */
+router.get(
+  '/yield-optimization',
+  [
+    query('pools')
+      .isString()
+      .notEmpty()
+      .withMessage('Query param "pools" is required (comma-separated addresses)'),
+  ],
+  validateRequest,
+  stakingController.getYieldOptimization
+);
 
 export default router;

--- a/api/src/services/staking.service.ts
+++ b/api/src/services/staking.service.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto';
 import type {
   StakingPosition,
   StakeRequest,
@@ -5,6 +6,14 @@ import type {
   DelegateRequest,
   RevokeDelegationRequest,
   StakingRewardConfig,
+  YieldFarmingStrategy,
+  YieldStrategyPerformance,
+  YieldOptimizationRecommendation,
+  CreateYieldStrategyRequest,
+  ActivateYieldStrategyRequest,
+  CompoundStrategyRequest,
+  PoolAllocation,
+  StrategyPerformanceSnapshot,
 } from '../types/staking';
 import logger from '../utils/logger';
 
@@ -19,6 +28,38 @@ const LOCKUP_OPTIONS = [0, 30, 90, 180, 365];
 
 // In-memory store. Replace with DB/Redis in production.
 const positions = new Map<string, StakingPosition>();
+
+// ─── Yield Farming in-memory stores ──────────────────────────────────────────
+
+/** All persisted strategies keyed by strategyId */
+const yieldStrategies = new Map<string, YieldFarmingStrategy>();
+
+/** Performance snapshots keyed by strategyId */
+const yieldPerformance = new Map<string, StrategyPerformanceSnapshot[]>();
+
+/**
+ * APY lookup table used by the optimizer.
+ * In production these would come from an on-chain oracle or price feed.
+ */
+const POOL_APY_ESTIMATES: Record<string, number> = {};
+
+/** Minimum total allocation BPS required when creating a strategy */
+const TOTAL_ALLOCATION_BPS = 10_000;
+
+/** Base APY boost granted by auto-compounding per interval (mirrors vault service) */
+const COMPOUND_INTERVAL_MULTIPLIERS: Record<string, number> = {
+  hourly: 1.35,
+  daily: 1.28,
+  weekly: 1.15,
+  manual: 1.0,
+};
+
+/** Risk-tier APY caps (bps) – conservative strategies get capped yield */
+const RISK_APY_CAP: Record<string, number> = {
+  conservative: 8,
+  balanced: 18,
+  aggressive: 40,
+};
 
 function now(): string {
   return new Date().toISOString();
@@ -56,6 +97,38 @@ function accrueRewards(position: StakingPosition): string {
 
   const current = BigInt(position.earnedRewards);
   return (current + reward).toString();
+}
+
+// ─── Yield farming pure helpers ───────────────────────────────────────────────
+
+/**
+ * Compute the weighted-average APY across pools, capped by the risk tier.
+ */
+function computeBlendedApy(pools: PoolAllocation[], riskTier: string): number {
+  if (pools.length === 0) return 0;
+  const weighted = pools.reduce(
+    (sum, p) => sum + p.estimatedApy * p.allocationBps,
+    0
+  );
+  const raw = weighted / TOTAL_ALLOCATION_BPS;
+  const cap = RISK_APY_CAP[riskTier] ?? 40;
+  return Math.round(Math.min(raw, cap) * 100) / 100;
+}
+
+/**
+ * Compute the ISO timestamp for the next scheduled compound based on the
+ * chosen compounding interval.
+ */
+function computeNextCompoundAt(interval: string): string {
+  const intervalMs: Record<string, number> = {
+    hourly: 60 * 60 * 1000,
+    daily: 24 * 60 * 60 * 1000,
+    weekly: 7 * 24 * 60 * 60 * 1000,
+    manual: 0,
+  };
+  const ms = intervalMs[interval] ?? intervalMs['daily']!;
+  if (ms === 0) return '';
+  return new Date(Date.now() + ms).toISOString();
 }
 
 export class StakingService {
@@ -269,6 +342,334 @@ export class StakingService {
       ...p,
       earnedRewards: accrueRewards(p),
     }));
+  }
+
+  // ─── Yield Farming Strategy Optimizer ──────────────────────────────────────
+
+  /**
+   * Create a new yield farming strategy for a user.
+   * Validates that pool allocations sum to 10 000 bps and that each pool
+   * address is non-empty, then persists the strategy in the in-memory store.
+   */
+  createYieldStrategy(req: CreateYieldStrategyRequest): YieldFarmingStrategy {
+    if (!req.userAddress) {
+      throw Object.assign(new Error('userAddress is required'), { status: 400 });
+    }
+    if (!req.pools || req.pools.length === 0) {
+      throw Object.assign(new Error('At least one pool allocation is required'), { status: 400 });
+    }
+
+    const totalBps = req.pools.reduce((sum, p) => sum + p.allocationBps, 0);
+    if (totalBps !== TOTAL_ALLOCATION_BPS) {
+      throw Object.assign(
+        new Error(`Pool allocations must sum to ${TOTAL_ALLOCATION_BPS} bps, got ${totalBps}`),
+        { status: 400 }
+      );
+    }
+
+    for (const p of req.pools) {
+      if (!p.poolAddress || p.poolAddress.trim() === '') {
+        throw Object.assign(new Error('Each pool must have a non-empty poolAddress'), {
+          status: 400,
+        });
+      }
+      if (p.allocationBps <= 0) {
+        throw Object.assign(new Error('Each pool allocationBps must be positive'), { status: 400 });
+      }
+    }
+
+    // Deactivate any currently active strategy for this user
+    for (const [id, strat] of yieldStrategies) {
+      if (strat.userAddress === req.userAddress && strat.active) {
+        yieldStrategies.set(id, { ...strat, active: false, updatedAt: now() });
+      }
+    }
+
+    // Enrich pools with utilization snapshot (defaults to 0 if unknown)
+    const enrichedPools: PoolAllocation[] = req.pools.map((p) => ({
+      ...p,
+      currentUtilizationBps: 0,
+      estimatedApy: POOL_APY_ESTIMATES[p.poolAddress] ?? p.estimatedApy,
+    }));
+
+    const blendedApy = computeBlendedApy(enrichedPools, req.riskTier);
+    const compoundMultiplier = COMPOUND_INTERVAL_MULTIPLIERS[req.compoundingInterval] ?? 1.28;
+    const effectiveApy = req.autoCompoundEnabled !== false
+      ? Math.round(blendedApy * compoundMultiplier * 100) / 100
+      : blendedApy;
+
+    const strategyId = randomUUID();
+    const ts = now();
+
+    const strategy: YieldFarmingStrategy = {
+      strategyId,
+      userAddress: req.userAddress,
+      name: req.name,
+      objective: req.objective,
+      riskTier: req.riskTier,
+      compoundingInterval: req.compoundingInterval,
+      pools: enrichedPools,
+      totalAllocatedBps: TOTAL_ALLOCATION_BPS,
+      estimatedBlendedApy: effectiveApy,
+      autoCompoundEnabled: req.autoCompoundEnabled !== false,
+      active: true,
+      createdAt: ts,
+      updatedAt: ts,
+      nextCompoundAt: computeNextCompoundAt(req.compoundingInterval),
+    };
+
+    yieldStrategies.set(strategyId, strategy);
+    yieldPerformance.set(strategyId, []);
+
+    logger.info('Yield farming strategy created', {
+      strategyId,
+      userAddress: req.userAddress,
+      objective: req.objective,
+    });
+
+    return strategy;
+  }
+
+  /**
+   * Return all strategies for a specific user.
+   */
+  getUserYieldStrategies(userAddress: string): YieldFarmingStrategy[] {
+    return Array.from(yieldStrategies.values()).filter(
+      (s) => s.userAddress === userAddress
+    );
+  }
+
+  /**
+   * Return all available (active) strategies across all users.
+   * Used by the strategy listing endpoint.
+   */
+  getAllYieldStrategies(): YieldFarmingStrategy[] {
+    return Array.from(yieldStrategies.values());
+  }
+
+  /**
+   * Activate a previously created (or deactivated) strategy.
+   * Automatically deactivates any other active strategy for the same user.
+   */
+  activateYieldStrategy(req: ActivateYieldStrategyRequest): YieldFarmingStrategy {
+    const strategy = yieldStrategies.get(req.strategyId);
+    if (!strategy) {
+      throw Object.assign(new Error('Strategy not found'), { status: 404 });
+    }
+    if (strategy.userAddress !== req.userAddress) {
+      throw Object.assign(new Error('Strategy does not belong to this user'), { status: 403 });
+    }
+    if (strategy.active) {
+      throw Object.assign(new Error('Strategy is already active'), { status: 400 });
+    }
+
+    // Deactivate any other active strategy for this user
+    for (const [id, strat] of yieldStrategies) {
+      if (id !== req.strategyId && strat.userAddress === req.userAddress && strat.active) {
+        yieldStrategies.set(id, { ...strat, active: false, updatedAt: now() });
+      }
+    }
+
+    const updated: YieldFarmingStrategy = {
+      ...strategy,
+      active: true,
+      updatedAt: now(),
+      nextCompoundAt: computeNextCompoundAt(strategy.compoundingInterval),
+    };
+    yieldStrategies.set(req.strategyId, updated);
+
+    logger.info('Yield farming strategy activated', {
+      strategyId: req.strategyId,
+      userAddress: req.userAddress,
+    });
+    return updated;
+  }
+
+  /**
+   * Manually trigger auto-compounding for a strategy.
+   * Records a performance snapshot, updates LP fee totals, and resets the
+   * next-compound timestamp.
+   */
+  compoundStrategy(req: CompoundStrategyRequest): {
+    strategy: YieldFarmingStrategy;
+    compoundedAmount: string;
+    newApy: number;
+  } {
+    const strategy = yieldStrategies.get(req.strategyId);
+    if (!strategy) {
+      throw Object.assign(new Error('Strategy not found'), { status: 404 });
+    }
+    if (strategy.userAddress !== req.userAddress) {
+      throw Object.assign(new Error('Strategy does not belong to this user'), { status: 403 });
+    }
+    if (!strategy.active) {
+      throw Object.assign(new Error('Cannot compound an inactive strategy'), { status: 400 });
+    }
+
+    // Simulate compound: estimate yield earned since last compound
+    const lastTs = strategy.lastCompoundedAt
+      ? new Date(strategy.lastCompoundedAt).getTime()
+      : new Date(strategy.createdAt).getTime();
+    const elapsedMs = Date.now() - lastTs;
+    const elapsedYears = elapsedMs / (365 * 24 * 60 * 60 * 1000);
+
+    // Simplified: compound on a nominal TVL of 1 000 000 stroops per active pool
+    const nominalTvl = strategy.pools.length * 1_000_000;
+    const compoundedRaw = Math.floor(nominalTvl * (strategy.estimatedBlendedApy / 100) * elapsedYears);
+    const compoundedAmount = Math.max(compoundedRaw, 0).toString();
+
+    // Re-score APY with compounding boost
+    const multiplier = COMPOUND_INTERVAL_MULTIPLIERS[strategy.compoundingInterval] ?? 1.28;
+    const newBlended = computeBlendedApy(strategy.pools, strategy.riskTier);
+    const newApy = Math.round(newBlended * multiplier * 100) / 100;
+
+    const ts = now();
+    const snapshot: StrategyPerformanceSnapshot = {
+      timestamp: ts,
+      totalValueLocked: String(nominalTvl),
+      yieldEarned: compoundedAmount,
+      compoundedAmount,
+      apy: newApy,
+      ilImpactBps: 0, // IL impact tracked on-chain; 0 in API layer simulation
+    };
+
+    const snapshots = yieldPerformance.get(req.strategyId) ?? [];
+    snapshots.push(snapshot);
+    yieldPerformance.set(req.strategyId, snapshots);
+
+    const updated: YieldFarmingStrategy = {
+      ...strategy,
+      estimatedBlendedApy: newApy,
+      lastCompoundedAt: ts,
+      nextCompoundAt: computeNextCompoundAt(strategy.compoundingInterval),
+      updatedAt: ts,
+    };
+    yieldStrategies.set(req.strategyId, updated);
+
+    logger.info('Strategy compounded', {
+      strategyId: req.strategyId,
+      compoundedAmount,
+      newApy,
+    });
+
+    return { strategy: updated, compoundedAmount, newApy };
+  }
+
+  /**
+   * Return aggregated performance data for a strategy.
+   */
+  getStrategyPerformance(strategyId: string, userAddress: string): YieldStrategyPerformance {
+    const strategy = yieldStrategies.get(strategyId);
+    if (!strategy) {
+      throw Object.assign(new Error('Strategy not found'), { status: 404 });
+    }
+    if (strategy.userAddress !== userAddress) {
+      throw Object.assign(new Error('Strategy does not belong to this user'), { status: 403 });
+    }
+
+    const snapshots = yieldPerformance.get(strategyId) ?? [];
+
+    const totalYieldEarned = snapshots
+      .reduce((sum, s) => sum + BigInt(s.yieldEarned), BigInt(0))
+      .toString();
+
+    const totalCompounded = snapshots
+      .reduce((sum, s) => sum + BigInt(s.compoundedAmount), BigInt(0))
+      .toString();
+
+    const averageIlImpactBps =
+      snapshots.length > 0
+        ? Math.round(snapshots.reduce((sum, s) => sum + s.ilImpactBps, 0) / snapshots.length)
+        : 0;
+
+    const realizedApy =
+      snapshots.length > 0
+        ? Math.round((snapshots.reduce((sum, s) => sum + s.apy, 0) / snapshots.length) * 100) / 100
+        : strategy.estimatedBlendedApy;
+
+    return {
+      strategyId,
+      userAddress,
+      totalYieldEarned,
+      totalCompounded,
+      compoundCount: snapshots.length,
+      realizedApy,
+      averageIlImpactBps,
+      snapshots,
+    };
+  }
+
+  /**
+   * Run the pool allocation optimizer over a list of pool addresses.
+   * Mirrors the on-chain `optimize_allocation` logic in amm.rs but operates
+   * on API-layer utilization data so callers can preview recommendations
+   * without submitting an on-chain transaction.
+   *
+   * Optimal utilization target: 80 % (8 000 bps).
+   * Rebalance threshold:          5 % (  500 bps).
+   */
+  getYieldOptimizationRecommendation(
+    poolAddresses: string[],
+    utilizationMap: Record<string, number> = {}
+  ): YieldOptimizationRecommendation {
+    if (!poolAddresses || poolAddresses.length === 0) {
+      throw Object.assign(new Error('At least one pool address is required'), { status: 400 });
+    }
+
+    const OPTIMAL_BPS = 8_000;
+    const REBALANCE_THRESHOLD_BPS = 500;
+    const DEFAULT_BUFFER_BPS = 8_000;
+
+    let totalUtilization = 0;
+
+    const pools = poolAddresses.map((addr) => {
+      const currentUtilizationBps = utilizationMap[addr] ?? 0;
+      totalUtilization += currentUtilizationBps;
+
+      const deviation = Math.abs(currentUtilizationBps - OPTIMAL_BPS);
+      let action: 'increase' | 'decrease' | 'no_change';
+      let adjustmentAmount: number;
+
+      if (deviation < REBALANCE_THRESHOLD_BPS) {
+        action = 'no_change';
+        adjustmentAmount = 0;
+      } else if (currentUtilizationBps < OPTIMAL_BPS) {
+        action = 'increase';
+        const available = 10_000 - DEFAULT_BUFFER_BPS;
+        adjustmentAmount = Math.floor(
+          (available * (OPTIMAL_BPS - currentUtilizationBps)) / 10_000
+        );
+      } else {
+        action = 'decrease';
+        const excess = currentUtilizationBps - OPTIMAL_BPS;
+        adjustmentAmount = Math.floor((excess * currentUtilizationBps) / 10_000);
+      }
+
+      return {
+        poolAddress: addr,
+        currentUtilizationBps,
+        recommendedAllocationBps: OPTIMAL_BPS,
+        action,
+        adjustmentAmount,
+      };
+    });
+
+    const avgUtilization =
+      poolAddresses.length > 0 ? Math.floor(totalUtilization / poolAddresses.length) : 0;
+
+    const efficiency = Math.min(avgUtilization, OPTIMAL_BPS);
+
+    const estimatedYieldImprovementBps =
+      avgUtilization < OPTIMAL_BPS
+        ? Math.floor((OPTIMAL_BPS - avgUtilization) / 100)
+        : 0;
+
+    return {
+      pools,
+      totalCapitalEfficiencyBps: efficiency,
+      estimatedYieldImprovementBps,
+      generatedAt: now(),
+    };
   }
 }
 

--- a/api/src/types/staking.ts
+++ b/api/src/types/staking.ts
@@ -40,3 +40,100 @@ export interface StakingRewardConfig {
   lockupBonusBps: number;
   epochDurationSeconds: number;
 }
+
+// ─── Yield Farming Strategy Optimizer Types ───────────────────────────────────
+
+/** Risk profile for a yield farming strategy */
+export type YieldStrategyRisk = 'conservative' | 'balanced' | 'aggressive';
+
+/** Objective the optimizer should prioritise */
+export type YieldStrategyObjective = 'maximize_apy' | 'minimize_il' | 'balanced';
+
+/** Compounding cadence */
+export type CompoundingInterval = 'hourly' | 'daily' | 'weekly' | 'manual';
+
+/** Per-pool allocation within a strategy */
+export interface PoolAllocation {
+  poolAddress: string;
+  allocationBps: number; // basis points, e.g. 5000 = 50 %
+  estimatedApy: number;  // annualised %, e.g. 12.5
+  currentUtilizationBps: number;
+}
+
+/** A complete yield farming strategy */
+export interface YieldFarmingStrategy {
+  strategyId: string;
+  userAddress: string;
+  name: string;
+  objective: YieldStrategyObjective;
+  riskTier: YieldStrategyRisk;
+  compoundingInterval: CompoundingInterval;
+  pools: PoolAllocation[];
+  totalAllocatedBps: number;    // must sum to 10 000
+  estimatedBlendedApy: number;  // weighted average APY
+  autoCompoundEnabled: boolean;
+  active: boolean;
+  createdAt: string;
+  updatedAt: string;
+  lastCompoundedAt?: string;
+  nextCompoundAt?: string;
+}
+
+/** Request body for creating / updating a yield farming strategy */
+export interface CreateYieldStrategyRequest {
+  userAddress: string;
+  name: string;
+  objective: YieldStrategyObjective;
+  riskTier: YieldStrategyRisk;
+  compoundingInterval: CompoundingInterval;
+  pools: Omit<PoolAllocation, 'currentUtilizationBps'>[];
+  autoCompoundEnabled?: boolean;
+}
+
+/** Request body for activating / deactivating a strategy */
+export interface ActivateYieldStrategyRequest {
+  userAddress: string;
+  strategyId: string;
+}
+
+/** Request body for a manual compound trigger */
+export interface CompoundStrategyRequest {
+  userAddress: string;
+  strategyId: string;
+}
+
+/** A single performance snapshot for a strategy */
+export interface StrategyPerformanceSnapshot {
+  timestamp: string;
+  totalValueLocked: string;
+  yieldEarned: string;
+  compoundedAmount: string;
+  apy: number;
+  ilImpactBps: number;
+}
+
+/** Aggregated performance for a strategy */
+export interface YieldStrategyPerformance {
+  strategyId: string;
+  userAddress: string;
+  totalYieldEarned: string;
+  totalCompounded: string;
+  compoundCount: number;
+  realizedApy: number;
+  averageIlImpactBps: number;
+  snapshots: StrategyPerformanceSnapshot[];
+}
+
+/** Optimizer recommendation for a set of pools */
+export interface YieldOptimizationRecommendation {
+  pools: Array<{
+    poolAddress: string;
+    currentUtilizationBps: number;
+    recommendedAllocationBps: number;
+    action: 'increase' | 'decrease' | 'no_change';
+    adjustmentAmount: number;
+  }>;
+  totalCapitalEfficiencyBps: number;
+  estimatedYieldImprovementBps: number;
+  generatedAt: string;
+}

--- a/stellar-lend/contracts/hello-world/src/amm.rs
+++ b/stellar-lend/contracts/hello-world/src/amm.rs
@@ -577,3 +577,317 @@ pub fn get_pool_utilization(env: &Env, asset: &Address) -> i128 {
         .get::<AmmLendingKey, i128>(&key)
         .unwrap_or(0)
 }
+
+// ─── Yield Farming Strategy Optimizer (#789) ─────────────────────────────────
+
+/// Risk profile governing how aggressively capital is deployed.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum YieldStrategyRisk {
+    /// Prioritise capital preservation; lower APY target.
+    Conservative,
+    /// Balance between yield and impermanent-loss exposure.
+    Balanced,
+    /// Maximise yield; accepts higher IL and liquidation risk.
+    Aggressive,
+}
+
+/// Primary optimisation objective for the strategy.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum YieldStrategyObjective {
+    /// Allocate towards the highest-APY pool(s).
+    MaximizeApy,
+    /// Minimise impermanent-loss exposure across the portfolio.
+    MinimizeIl,
+    /// Weighted balance between APY maximisation and IL minimisation.
+    Balanced,
+}
+
+/// How frequently the strategy auto-compounds accrued fees.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum CompoundingInterval {
+    Hourly,
+    Daily,
+    Weekly,
+    /// Compound only when explicitly triggered by the admin.
+    Manual,
+}
+
+/// A named yield farming strategy stored on-chain per admin address.
+///
+/// Strategies are keyed by `YieldStrategyKey::Strategy(admin, strategy_id)`
+/// in persistent storage so they survive ledger TTL extension cycles.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct YieldStrategy {
+    /// Incrementing identifier scoped to the admin address.
+    pub strategy_id: u64,
+    /// Friendly name for the strategy.
+    pub name: String,
+    /// Optimisation objective.
+    pub objective: YieldStrategyObjective,
+    /// Risk tolerance.
+    pub risk: YieldStrategyRisk,
+    /// Compounding cadence.
+    pub compounding_interval: CompoundingInterval,
+    /// Pool addresses included in this strategy.
+    pub pools: Vec<Address>,
+    /// Whether the strategy is currently active.
+    pub active: bool,
+    /// Ledger timestamp of the last compound execution (0 = never run).
+    pub last_compounded_at: u64,
+    /// Cumulative LP fees compounded by this strategy (stroops).
+    pub total_compounded: i128,
+}
+
+/// Score assigned to a strategy after an optimisation pass.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct StrategyScore {
+    pub strategy_id: u64,
+    /// Blended APY estimate in basis points (e.g. 1200 = 12 %).
+    pub estimated_apy_bps: i128,
+    /// Aggregate IL risk score across all pools (lower is safer).
+    pub il_risk_score_bps: i128,
+    /// Composite score used for ranking (higher is better).
+    pub composite_score_bps: i128,
+}
+
+/// Storage keys for yield strategy objects.
+#[contracttype]
+#[derive(Clone)]
+pub enum YieldStrategyKey {
+    /// `(admin_address, strategy_id) -> YieldStrategy`
+    Strategy(Address, u64),
+    /// `admin_address -> u64` — monotonic counter for strategy IDs.
+    StrategyCounter(Address),
+}
+
+// ─── Strategy CRUD ────────────────────────────────────────────────────────────
+
+/// Create and persist a new yield farming strategy.
+///
+/// Returns the newly assigned `strategy_id`.
+pub fn create_yield_strategy(
+    env: &Env,
+    admin: Address,
+    name: String,
+    objective: YieldStrategyObjective,
+    risk: YieldStrategyRisk,
+    compounding_interval: CompoundingInterval,
+    pools: Vec<Address>,
+) -> Result<u64, AmmError> {
+    require_amm_admin(env, &admin)?;
+
+    if pools.is_empty() {
+        return Err(AmmError::InvalidSwapParams);
+    }
+
+    // Increment the per-admin strategy counter.
+    let counter_key = YieldStrategyKey::StrategyCounter(admin.clone());
+    let strategy_id: u64 = env
+        .storage()
+        .persistent()
+        .get::<YieldStrategyKey, u64>(&counter_key)
+        .unwrap_or(0)
+        .saturating_add(1);
+
+    env.storage()
+        .persistent()
+        .set(&counter_key, &strategy_id);
+
+    let strategy = YieldStrategy {
+        strategy_id,
+        name,
+        objective,
+        risk,
+        compounding_interval,
+        pools,
+        active: true,
+        last_compounded_at: 0,
+        total_compounded: 0,
+    };
+
+    env.storage()
+        .persistent()
+        .set(&YieldStrategyKey::Strategy(admin.clone(), strategy_id), &strategy);
+
+    Ok(strategy_id)
+}
+
+/// Retrieve a previously created strategy.
+pub fn get_yield_strategy(
+    env: &Env,
+    admin: &Address,
+    strategy_id: u64,
+) -> Option<YieldStrategy> {
+    env.storage()
+        .persistent()
+        .get(&YieldStrategyKey::Strategy(admin.clone(), strategy_id))
+}
+
+/// Activate or deactivate a strategy.
+pub fn set_yield_strategy_active(
+    env: &Env,
+    admin: Address,
+    strategy_id: u64,
+    active: bool,
+) -> Result<(), AmmError> {
+    require_amm_admin(env, &admin)?;
+
+    let key = YieldStrategyKey::Strategy(admin.clone(), strategy_id);
+    let mut strategy: YieldStrategy = env
+        .storage()
+        .persistent()
+        .get(&key)
+        .ok_or(AmmError::InvalidSwapParams)?;
+
+    strategy.active = active;
+    env.storage().persistent().set(&key, &strategy);
+    Ok(())
+}
+
+// ─── harvest_and_compound ─────────────────────────────────────────────────────
+
+/// Harvest accrued LP fees for every pool in a strategy and compound them
+/// back into the respective LP positions in one atomic call.
+///
+/// This is the on-chain half of the "yield farming strategy optimizer with
+/// auto-compounding" feature (#789).  It:
+///
+/// 1. Iterates each pool address registered in the strategy.
+/// 2. Calls the existing `compound_lp_fees` helper for each pool.
+/// 3. Accumulates the total compounded amount.
+/// 4. Updates `last_compounded_at` and `total_compounded` on the strategy.
+///
+/// Returns the total amount of LP fees compounded across all pools.
+pub fn harvest_and_compound(
+    env: &Env,
+    admin: Address,
+    strategy_id: u64,
+) -> Result<i128, AmmError> {
+    require_amm_admin(env, &admin)?;
+
+    let key = YieldStrategyKey::Strategy(admin.clone(), strategy_id);
+    let mut strategy: YieldStrategy = env
+        .storage()
+        .persistent()
+        .get(&key)
+        .ok_or(AmmError::InvalidSwapParams)?;
+
+    if !strategy.active {
+        return Err(AmmError::Unauthorized);
+    }
+
+    let mut total_compounded: i128 = 0;
+
+    // Collect pool addresses first to avoid borrowing env inside the loop body
+    // while also calling compound_lp_fees (which also borrows env mutably).
+    let pools: Vec<Address> = strategy.pools.clone();
+
+    for pool in pools.iter() {
+        // compound_lp_fees is a no-op (returns Ok(0)) when there's nothing
+        // accrued, so we can safely call it unconditionally.
+        let compounded = compound_lp_fees(env, admin.clone(), pool.clone())?;
+        total_compounded = total_compounded.saturating_add(compounded);
+    }
+
+    // Persist the updated counters back onto the strategy.
+    strategy.last_compounded_at = env.ledger().timestamp();
+    strategy.total_compounded = strategy.total_compounded.saturating_add(total_compounded);
+    env.storage().persistent().set(&key, &strategy);
+
+    Ok(total_compounded)
+}
+
+// ─── Strategy Scoring ─────────────────────────────────────────────────────────
+
+/// Score a strategy based on current pool utilization and IL snapshots.
+///
+/// The composite score weighs APY potential against IL risk according to
+/// the strategy's own `objective`:
+///
+/// - `MaximizeApy`  → weight 80 % APY, 20 % IL safety
+/// - `MinimizeIl`   → weight 20 % APY, 80 % IL safety
+/// - `Balanced`     → weight 50 % APY, 50 % IL safety
+///
+/// Returns a `StrategyScore` that callers can compare across strategies to
+/// rank them and surface the best candidate for the current market regime.
+pub fn score_yield_strategy(
+    env: &Env,
+    admin: &Address,
+    strategy_id: u64,
+) -> Result<StrategyScore, AmmError> {
+    let strategy: YieldStrategy = env
+        .storage()
+        .persistent()
+        .get(&YieldStrategyKey::Strategy(admin.clone(), strategy_id))
+        .ok_or(AmmError::InvalidSwapParams)?;
+
+    let pool_count = strategy.pools.len() as i128;
+    if pool_count == 0 {
+        return Err(AmmError::InvalidSwapParams);
+    }
+
+    let mut total_utilization: i128 = 0;
+    let mut total_il_risk: i128 = 0;
+
+    for pool in strategy.pools.iter() {
+        // Utilization serves as a proxy for lending APY:
+        // higher utilization → higher borrow rate → higher supply yield.
+        let utilization = get_pool_utilization(env, &pool);
+        total_utilization = total_utilization.saturating_add(utilization);
+
+        // IL risk is derived from the price-ratio BPS stored in IlSnapshot.
+        // A ratio far below BPS_SCALE indicates a significant price move, i.e.
+        // higher IL risk.  We express "IL risk" as the deviation from 1.0.
+        let il_risk = match get_il_snapshot(env, &pool) {
+            Some(snap) => {
+                let deviation = if snap.price_ratio_bps < BPS_SCALE {
+                    BPS_SCALE - snap.price_ratio_bps
+                } else {
+                    snap.price_ratio_bps - BPS_SCALE
+                };
+                deviation
+            }
+            None => 0,
+        };
+        total_il_risk = total_il_risk.saturating_add(il_risk);
+    }
+
+    // Average across pools.
+    let avg_utilization = total_utilization.checked_div(pool_count).unwrap_or(0);
+    let avg_il_risk = total_il_risk.checked_div(pool_count).unwrap_or(0);
+
+    // Map average utilization to an estimated APY in bps.
+    // Simple linear model: 0 % util → 0 bps APY, 100 % util → 2 000 bps (20 %).
+    let estimated_apy_bps = avg_utilization
+        .saturating_mul(2_000)
+        .checked_div(BPS_SCALE)
+        .unwrap_or(0);
+
+    // IL safety score (higher = safer): BPS_SCALE minus the average IL risk.
+    let il_safety_bps = BPS_SCALE.saturating_sub(avg_il_risk).max(0);
+
+    // Objective-weighted composite score.
+    let (apy_weight, il_weight) = match strategy.objective {
+        YieldStrategyObjective::MaximizeApy => (8_000i128, 2_000i128),
+        YieldStrategyObjective::MinimizeIl  => (2_000i128, 8_000i128),
+        YieldStrategyObjective::Balanced    => (5_000i128, 5_000i128),
+    };
+
+    let composite_score_bps = (estimated_apy_bps
+        .saturating_mul(apy_weight)
+        .saturating_add(il_safety_bps.saturating_mul(il_weight)))
+    .checked_div(BPS_SCALE)
+    .unwrap_or(0);
+
+    Ok(StrategyScore {
+        strategy_id,
+        estimated_apy_bps,
+        il_risk_score_bps: avg_il_risk,
+        composite_score_bps,
+    })
+}

--- a/stellar-lend/contracts/hello-world/src/lib.rs
+++ b/stellar-lend/contracts/hello-world/src/lib.rs
@@ -33,6 +33,7 @@ pub mod storage;
 pub mod treasury;
 pub mod types;
 pub mod withdraw;
+pub mod amm;
 
 use crate::deposit::Position;
 use crate::errors::LendingError;
@@ -1024,6 +1025,212 @@ impl HelloContract {
         freeze: bool,
     ) -> Result<(), LendingError> {
         cross_asset::freeze_pool(&env, caller, asset, freeze).map_err(Into::into)
+    }
+
+    // -------------------------------------------------------------------------
+    // AMM-Lending Integration: LP Wrapping & Auto-Allocation
+    // -------------------------------------------------------------------------
+
+    /// Initialise the AMM-lending module (admin-only, once).
+    pub fn amm_initialize(env: Env, admin: Address) -> Result<(), LendingError> {
+        amm::initialize_amm_lending(&env, admin)
+            .map_err(|_| LendingError::Unauthorized)
+    }
+
+    /// Wrap lending pool deposits into AMM LP positions.
+    pub fn amm_wrap_deposit(
+        env: Env,
+        admin: Address,
+        asset: Address,
+        amount: i128,
+        amm_protocol: Address,
+    ) -> Result<amm::LpTokenPosition, LendingError> {
+        amm::wrap_deposit_to_lp(&env, admin, asset, amount, amm_protocol)
+            .map_err(|_| LendingError::InvalidAmount)
+    }
+
+    /// Unwrap LP tokens back into lending pool assets.
+    pub fn amm_unwrap_deposit(
+        env: Env,
+        admin: Address,
+        asset: Address,
+        lp_tokens: i128,
+    ) -> Result<i128, LendingError> {
+        amm::unwrap_lp_to_deposit(&env, admin, asset, lp_tokens)
+            .map_err(|_| LendingError::InvalidAmount)
+    }
+
+    /// Return the LP token balance for an asset.
+    pub fn amm_get_lp_balance(env: Env, asset: Address) -> i128 {
+        amm::get_lp_token_balance(&env, &asset)
+    }
+
+    /// Set the withdrawal buffer BPS for an asset (admin-only).
+    pub fn amm_set_withdrawal_buffer(
+        env: Env,
+        admin: Address,
+        asset: Address,
+        buffer_bps: i128,
+    ) -> Result<(), LendingError> {
+        amm::set_withdrawal_buffer(&env, admin, asset, buffer_bps)
+            .map_err(|_| LendingError::InvalidAmount)
+    }
+
+    /// Record accrued LP fees for an asset (admin-only).
+    pub fn amm_record_lp_fees(
+        env: Env,
+        admin: Address,
+        asset: Address,
+        fee_amount: i128,
+    ) -> Result<(), LendingError> {
+        amm::record_lp_fees(&env, admin, asset, fee_amount)
+            .map_err(|_| LendingError::InvalidAmount)
+    }
+
+    /// Auto-compound accrued LP fees back into the LP position for a single asset.
+    ///
+    /// Returns the total amount compounded (0 when nothing was accrued).
+    pub fn amm_compound_lp_fees(
+        env: Env,
+        admin: Address,
+        asset: Address,
+    ) -> Result<i128, LendingError> {
+        amm::compound_lp_fees(&env, admin, asset)
+            .map_err(|_| LendingError::InvalidAmount)
+    }
+
+    /// Calculate optimal AMM allocation given current pool utilization.
+    pub fn amm_calculate_optimal_allocation(
+        env: Env,
+        asset: Address,
+        total_liquidity: i128,
+        borrowed_amount: i128,
+    ) -> Result<amm::AllocationSuggestion, LendingError> {
+        amm::calculate_optimal_allocation(&env, &asset, total_liquidity, borrowed_amount)
+            .map_err(|_| LendingError::InvalidAmount)
+    }
+
+    /// Execute automated AMM rebalancing based on pool utilization.
+    pub fn amm_auto_rebalance(
+        env: Env,
+        admin: Address,
+        asset: Address,
+        total_liquidity: i128,
+        borrowed_amount: i128,
+        current_amm_balance: i128,
+    ) -> Result<i128, LendingError> {
+        amm::auto_rebalance_allocation(
+            &env,
+            admin,
+            asset,
+            total_liquidity,
+            borrowed_amount,
+            current_amm_balance,
+        )
+        .map_err(|_| LendingError::InvalidAmount)
+    }
+
+    /// Run the pool allocation optimizer across a set of pool addresses and
+    /// return per-pool rebalancing recommendations.
+    pub fn amm_optimize_allocation(
+        env: Env,
+        pools: Vec<Address>,
+    ) -> Result<amm::OptimizationResult, LendingError> {
+        amm::optimize_allocation(&env, &pools)
+            .map_err(|_| LendingError::InvalidAmount)
+    }
+
+    /// Update the impermanent-loss tracking snapshot for an asset.
+    /// Returns `true` when the IL alert threshold has been crossed.
+    pub fn amm_update_il_tracking(
+        env: Env,
+        asset: Address,
+        current_price: i128,
+    ) -> Result<bool, LendingError> {
+        amm::update_il_tracking(&env, &asset, current_price)
+            .map_err(|_| LendingError::InvalidAmount)
+    }
+
+    /// Return the current IL snapshot for an asset, or `None` if not tracked.
+    pub fn amm_get_il_snapshot(env: Env, asset: Address) -> Option<amm::IlSnapshot> {
+        amm::get_il_snapshot(&env, &asset)
+    }
+
+    /// Update the utilization snapshot for a pool.
+    pub fn amm_update_pool_utilization(env: Env, asset: Address, utilization_bps: i128) {
+        amm::update_pool_utilization(&env, &asset, utilization_bps);
+    }
+
+    /// Return the current utilization snapshot for a pool.
+    pub fn amm_get_pool_utilization(env: Env, asset: Address) -> i128 {
+        amm::get_pool_utilization(&env, &asset)
+    }
+
+    // -------------------------------------------------------------------------
+    // Yield Farming Strategy Optimizer (#789)
+    // -------------------------------------------------------------------------
+
+    /// Create a new named yield farming strategy for the admin.
+    ///
+    /// Returns the newly assigned `strategy_id`.
+    pub fn yield_create_strategy(
+        env: Env,
+        admin: Address,
+        name: String,
+        objective: amm::YieldStrategyObjective,
+        risk: amm::YieldStrategyRisk,
+        compounding_interval: amm::CompoundingInterval,
+        pools: Vec<Address>,
+    ) -> Result<u64, LendingError> {
+        amm::create_yield_strategy(&env, admin, name, objective, risk, compounding_interval, pools)
+            .map_err(|_| LendingError::InvalidAmount)
+    }
+
+    /// Retrieve a previously created strategy by ID.
+    pub fn yield_get_strategy(
+        env: Env,
+        admin: Address,
+        strategy_id: u64,
+    ) -> Option<amm::YieldStrategy> {
+        amm::get_yield_strategy(&env, &admin, strategy_id)
+    }
+
+    /// Activate or deactivate a yield farming strategy (admin-only).
+    pub fn yield_set_strategy_active(
+        env: Env,
+        admin: Address,
+        strategy_id: u64,
+        active: bool,
+    ) -> Result<(), LendingError> {
+        amm::set_yield_strategy_active(&env, admin, strategy_id, active)
+            .map_err(|_| LendingError::Unauthorized)
+    }
+
+    /// Harvest and auto-compound accrued LP fees for every pool in a strategy.
+    ///
+    /// This is the primary on-chain entry point for the yield farming
+    /// auto-compounding feature.  Returns the total amount compounded.
+    pub fn yield_harvest_and_compound(
+        env: Env,
+        admin: Address,
+        strategy_id: u64,
+    ) -> Result<i128, LendingError> {
+        amm::harvest_and_compound(&env, admin, strategy_id)
+            .map_err(|_| LendingError::InvalidAmount)
+    }
+
+    /// Score a strategy based on current pool utilization and IL snapshots.
+    ///
+    /// Returns a `StrategyScore` with estimated APY, IL risk, and a composite
+    /// ranking score so callers can compare strategies and pick the best one
+    /// for the current market regime.
+    pub fn yield_score_strategy(
+        env: Env,
+        admin: Address,
+        strategy_id: u64,
+    ) -> Result<amm::StrategyScore, LendingError> {
+        amm::score_yield_strategy(&env, &admin, strategy_id)
+            .map_err(|_| LendingError::InvalidAmount)
     }
 }
 


### PR DESCRIPTION
feat: yield farming strategy optimizer with auto-compounding

closes #786 
closes #789 

- Add YieldFarmingStrategy types, enums and request/response interfaces
  to api/src/types/staking.ts

- Add createYieldStrategy, getUserYieldStrategies, getAllYieldStrategies,
  activateYieldStrategy, compoundStrategy, getStrategyPerformance and
  getYieldOptimizationRecommendation to StakingService in
  api/src/services/staking.service.ts

- Add matching controller handlers in
  api/src/controllers/staking.controller.ts

- Add 7 new routes to api/src/routes/staking.routes.ts:
    POST   /yield-strategies
    GET    /yield-strategies
    GET    /yield-strategies/:userAddress
    POST   /yield-strategies/:userAddress/activate
    POST   /yield-strategies/:userAddress/compound
    GET    /yield-strategies/:userAddress/performance/:strategyId
    GET    /yield-optimization

- Add YieldStrategy struct, YieldStrategyRisk, YieldStrategyObjective,
  CompoundingInterval enums, StrategyScore struct and YieldStrategyKey
  storage enum to stellar-lend/contracts/hello-world/src/amm.rs

- Add harvest_and_compound (atomic LP fee compounding across all pools
  in a strategy) and score_yield_strategy (objective-weighted APY vs IL
  composite scoring) to amm.rs

- Declare pub mod amm and wire 14 AMM-lending entry points plus 5 yield
  farming entry points into HelloContract contractimpl in
  stellar-lend/contracts/hello-world/src/lib.rs

Closes #785 
closes #788 
